### PR TITLE
Provide request options to data and interaction providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {},
   "devDependencies": {
     "@angular/animations": ">=4.0.0-beta <5.0.0",
-    "@angular/cli": "^1.0.0-rc.2",
+    "@angular/cli": "1.0.0-rc.2",
     "@angular/common": ">=4.0.0-beta <5.0.0",
     "@angular/compiler": ">=4.0.0-beta <5.0.0",
     "@angular/compiler-cli": ">=4.0.0-beta <5.0.0",

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, PrimaryClientConfiguration} from '../protocol/data';
+import {Credential, CredentialHintOptions, PrimaryClientConfiguration} from '../protocol/data';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 /**
@@ -98,10 +98,16 @@ export interface ClientConfigurationProvider {
  */
 export interface CredentialDataProvider {
   /**
-   * Retrieves all credentials, optionally filtered to the provided set of
-   * domains.
+   * Retrieves all hint credentials, based upon the provided options.
    */
-  getAllCredentials(authDomains?: string[]): Promise<Credential[]>;
+  getAllHints(options: CredentialHintOptions): Promise<Credential[]>;
+
+  /**
+   * Retrieves all credentials for the specified authentication domains
+   * (derived from the request) and the specified request options.
+   */
+  getAllCredentials(authDomains: string[], options: CredentialRequestOptions):
+      Promise<Credential[]>;
 
   /**
    * Creates or updates an existing credential. If the credential cannot be
@@ -132,6 +138,7 @@ export interface InteractionProvider {
    */
   showCredentialPicker(
       credentials: Credential[],
+      options: CredentialRequestOptions,
       displayCallbacks: DisplayCallbacks): Promise<Credential>;
 
   /**
@@ -140,8 +147,10 @@ export interface InteractionProvider {
    * returned promise should resolve with that credential. If the user does
    * not select a credential, the promise should be rejected.
    */
-  showHintPicker(hints: Credential[], displayCallbacks: DisplayCallbacks):
-      Promise<Credential>;
+  showHintPicker(
+      hints: Credential[],
+      options: CredentialHintOptions,
+      displayCallbacks: DisplayCallbacks): Promise<Credential>;
 
   /**
    * Requests the display of a confirmation screen, allowing the user to

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -245,7 +245,7 @@ export class ProviderFrame {
     // user interaction is required. instruct the interaction provider to show
     // a picker for the available credentials.
     let selectionPromise = this.interactionProvider.showHintPicker(
-        hints, this.createDisplayCallbacks(requestId));
+        hints, options, this.createDisplayCallbacks(requestId));
 
     // now, wait for selection to occur, and send the selection result to the
     // client
@@ -288,7 +288,7 @@ export class ProviderFrame {
     console.info('Handling credential retrieve request');
 
     let credentials = await this.credentialDataProvider.getAllCredentials(
-        this.equivalentAuthDomains);
+        this.equivalentAuthDomains, options);
 
     // filter out the credentials which don't match the request options
     let pertinentCredentials = credentials.filter((credential) => {
@@ -325,7 +325,7 @@ export class ProviderFrame {
     // client to show the provider frame.
     console.info('User interaction required to release credential');
     let selectionPromise = this.interactionProvider.showCredentialPicker(
-        pertinentCredentials, this.createDisplayCallbacks(requestId));
+        pertinentCredentials, options, this.createDisplayCallbacks(requestId));
 
     // now, wait for selection to occur, and send the selection result to the
     // client
@@ -460,7 +460,7 @@ export class ProviderFrame {
       Promise<Credential[]> {
     // get all credentials across all domains; from this, we can filter down
     // to the set of credentials
-    let allCredentials = await this.credentialDataProvider.getAllCredentials();
+    let allCredentials = await this.credentialDataProvider.getAllHints(options);
 
     if (allCredentials.length < 1) {
       return [];

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -619,8 +619,8 @@ class TestCredentialDataProvider implements CredentialDataProvider {
   credentials: Credential[] = [];
   neverSave: {[key: string]: boolean} = {};
 
-  async getAllCredentials(authDomains?: string[]): Promise<Credential[]> {
-    if (!authDomains) {
+  async getAllCredentials(authDomains: string[]): Promise<Credential[]> {
+    if (authDomains.length < 1) {
       return this.credentials;
     }
 
@@ -635,6 +635,11 @@ class TestCredentialDataProvider implements CredentialDataProvider {
     }
 
     return filteredCredentials;
+  }
+
+  async getAllHints(options: CredentialHintOptions): Promise<Credential[]> {
+    // no filtering required in the hints case
+    return this.credentials;
   }
 
   /**


### PR DESCRIPTION
The client can specify request options that are needed by the
data and interaction providers to function correctly. These
were not being passed through to the providers for each request;
this is now rectified.