### PR TITLE
Add preload request parameter

### DIFF
--- a/ts/api/provider_frame_elem.ts
+++ b/ts/api/provider_frame_elem.ts
@@ -15,6 +15,7 @@
  */
 
 import {WindowLike} from '../protocol/comms';
+import {PreloadRequest} from '../protocol/preload_request';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 import {RENDER_MODES, RenderMode} from './api';
@@ -80,13 +81,20 @@ export class ProviderFrameElement {
       private instanceId: string,
       clientOrigin: string,
       private renderMode: RenderMode,
-      providerUrlBase: string) {
+      providerUrlBase: string,
+      preloadRequest?: PreloadRequest) {
     injectDefaultFrameCss();
     this.frameElem = this.clientDocument.createElement('iframe');
     this.frameElem.src = `${providerUrlBase}` +
         `?client=${encodeURIComponent(clientOrigin)}` +
         `&id=${this.instanceId}` +
         `&renderMode=${renderMode}`;
+
+    if (preloadRequest) {
+      let encodedRequest = encodeURIComponent(JSON.stringify(preloadRequest));
+      this.frameElem.src += `&preloadRequest=${encodedRequest}`;
+    }
+
     this.frameElem.className = HIDDEN_FRAME_CLASS;
     this.clientDocument.body.appendChild(this.frameElem);
   }

--- a/ts/protocol/client_config.ts
+++ b/ts/protocol/client_config.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OpenYOLO client configurations must reside at './well-known/openyolo.json'
+ * and may either be a "primary" configuration, containing the required
+ * properties, or a "reference" configuration, which indicates that the
+ * configuration can be found at another domain.
+ */
+export type ClientConfiguration =
+    PrimaryClientConfiguration | ReferencingClientConfiguration;
+
+/**
+ * An OpenYOLO client configuration that contains the minimum set of properties
+ * required
+ */
+export interface PrimaryClientConfiguration {
+  type: 'primary';
+
+  /**
+   * Whether OpenYOLO requests should be allowed for this client.
+   * Default: false.
+   */
+  apiEnabled?: boolean;
+
+  /**
+   * Whether usage of a credential should require proxied authentication via
+   * the credential provider.
+   * Default: false.
+   */
+  requireProxyLogin?: boolean;
+
+  /**
+   * Whether credential requests should be permitted from a context where
+   * the parent frame is not the root of the window.
+   * Default: false.
+   */
+  allowNestedFrameRequests?: boolean;
+
+  /**
+   * The authentication endpoint to which credentials should be sent, when
+   * using proxied authentication.
+   */
+  authenticationEndpoint?: string;
+}
+
+/**
+ * An OpenYOLO client configuration that refers to a configuration on another
+ * domain. This other domain must be provably related to the current domain
+ * though a bidirectional digital asset link association.
+ */
+export interface ReferencingClientConfiguration {
+  type: 'reference';
+  domain: string;
+}

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -22,6 +22,7 @@ import {PasswordSpecification} from './password_spec';
  * credential provider.
  */
 
+
 /**
  * Represents a credential which may be usable to sign in.
  */
@@ -97,16 +98,6 @@ export interface Credential {
   proxiedAuthRequired?: boolean;
 }
 
-/**
- * A token which provides some additional verifying information related to
- * the credential, such as an verifiable assertion that the user owns the
- * email address identifier associated with a credential. Interpretation of
- * the token value is provider-specific.
- */
-export interface CredentialToken {
-  provider: string;
-  token: string;
-}
 
 /**
  * Encapsulates the response from the authentication system to a proxy login.
@@ -116,6 +107,10 @@ export interface ProxyLoginResponse {
   responseText: string;
 }
 
+/**
+ * The set of parameters passed from the client for a credential retrieval
+ * request.
+ */
 export interface CredentialRequestOptions {
   /**
    * The supported authentication methods supported by the origin, described
@@ -135,10 +130,24 @@ export interface CredentialRequestOptions {
  * Defines a token provider by its canonical base URI.
  */
 export interface TokenProvider {
+  /**
+   * The URI of the token provider. See `TOKEN_PROVIDERS` for some common
+   * values.
+   */
   uri: string;
+
+  /**
+   * The optional OpenID Connect client ID for this app, in the context of this
+   * token provider.
+   */
+  clientId?: string;
+
   [param: string]: string;
 }
 
+/**
+ * The set of parameters passed from the client for a hint retrieval request.
+ */
 export interface CredentialHintOptions {
   /**
    * The supported authentication methods supported by the origin, described
@@ -166,60 +175,6 @@ export interface CredentialHintOptions {
    * explicitly provided, `DEFAULT_PASSWORD_GENERATION_SPEC` will be used.
    */
   passwordSpec?: PasswordSpecification;
-}
-
-
-/**
- * OpenYOLO client configurations must reside at './well-known/openyolo.json'
- * and may either be a "primary" configuration, containing the required
- * properties, or a "reference" configuration, which indicates that the
- * configuration can be found at another domain.
- */
-export type ClientConfiguration =
-    PrimaryClientConfiguration | ReferencingClientConfiguration;
-
-/**
- * An OpenYOLO client configuration that contains the minimum set of properties
- * required
- */
-export interface PrimaryClientConfiguration {
-  type: 'primary';
-
-  /**
-   * Whether OpenYOLO requests should be allowed for this client.
-   * Default: false.
-   */
-  apiEnabled?: boolean;
-
-  /**
-   * Whether usage of a credential should require proxied authentication via
-   * the credential provider.
-   * Default: false.
-   */
-  requireProxyLogin?: boolean;
-
-  /**
-   * Whether credential requests should be permitted from a context where
-   * the parent frame is not the root of the window.
-   * Default: false.
-   */
-  allowNestedFrameRequests?: boolean;
-
-  /**
-   * The authentication endpoint to which credentials should be sent, when
-   * using proxied authentication.
-   */
-  authenticationEndpoint?: string;
-}
-
-/**
- * An OpenYOLO client configuration that refers to a configuration on another
- * domain. This other domain must be provably related to the current domain
- * though a bidirectional digital asset link association.
- */
-export interface ReferencingClientConfiguration {
-  type: 'reference';
-  domain: string;
 }
 
 /**
@@ -251,4 +206,15 @@ export const AUTHENTICATION_METHODS = indexedStrEnum({
   PAYPAL: boxEnum('https://www.paypal.com'),
   TWITTER: boxEnum('https://twitter.com'),
   YAHOO: boxEnum('https://login.yahoo.com')
+});
+
+/**
+ * The set of commonly-used OpenID Connect token providers. This list is not
+ * intended to be an exhaustive enumeration of all token providers.  When
+ * referencing a token provider, use the origin related to its
+ * token endpoint.
+ */
+export const TOKEN_PROVIDERS = indexedStrEnum({
+  GOOGLE: boxEnum('https://accounts.google.com'),
+  MICROSOFT: boxEnum('https://login.live.com'),
 });

--- a/ts/protocol/preload_request.ts
+++ b/ts/protocol/preload_request.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file Specifies the request types that can be sent to the provider as an
+ * initial URL parameter, potentially allowing the provider backend to preload
+ * the necessary data to service that request. These requests MUST NOT contain
+ * sensitive information; in particular, credentials MUST NOT be passed in
+ * preload requests.
+ */
+
+/**
+ * The types of request that can be relayed to the provider frame via an
+ * initial request parameter. This can help the provider preload information
+ * as part of the initial load of the iframe, to speed up handling of these
+ * requests.
+ */
+import {CredentialHintOptions} from './data';
+import {strEnum} from './enums';
+
+export const PRELOAD_REQUEST = strEnum('hint', 'retrieve');
+
+export interface HintPreloadRequest {
+  type: typeof PRELOAD_REQUEST.hint;
+  options: CredentialHintOptions;
+}
+
+export interface RetrievePreloadRequest {
+  type: typeof PRELOAD_REQUEST.retrieve;
+  options: CredentialRequestOptions;
+}
+
+export type PreloadRequest = HintPreloadRequest | RetrievePreloadRequest;

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialHintOptions, PrimaryClientConfiguration} from '../protocol/data';
+import {PrimaryClientConfiguration} from '../protocol/client_config';
+import {Credential, CredentialHintOptions} from '../protocol/data';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 /**

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import {PrimaryClientConfiguration} from '../protocol/client_config';
 import {sendMessage} from '../protocol/comms';
-import {AUTHENTICATION_METHODS, Credential, CredentialHintOptions, CredentialRequestOptions, PrimaryClientConfiguration} from '../protocol/data';
+import {AUTHENTICATION_METHODS, Credential, CredentialHintOptions, CredentialRequestOptions} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import {isOpenYoloMessageFormat} from '../protocol/messages';
 import {channelErrorMessage} from '../protocol/post_messages';

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, ClientConfiguration, Credential, CredentialHintOptions, CredentialRequestOptions, PrimaryClientConfiguration} from '../protocol/data';
+import {ClientConfiguration, PrimaryClientConfiguration} from '../protocol/client_config';
+import {AUTHENTICATION_METHODS, Credential, CredentialHintOptions, CredentialRequestOptions} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import * as msg from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';

--- a/ts/spi/spi.ts
+++ b/ts/spi/spi.ts
@@ -22,3 +22,4 @@
 export {ProviderFrame} from './provider_frame';
 export * from './provider_config';
 export * from '../protocol/data';
+export * from '../protocol/client_config';


### PR DESCRIPTION
The client's first hint or retrieve request is specified on the
provider frame URI, allowing backends to preload data into the
page for faster serving.