### PR TITLE
Handle concurrent requests without closing the IFrame

### DIFF
--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -109,6 +109,28 @@ describe('BaseRequest', () => {
       } catch (err) {
         expect(err).toEqual(expectedError);
         expect(request.dispose).toHaveBeenCalled();
+        expect(frame.hide).toHaveBeenCalled();
+        done();
+      }
+    });
+  });
+
+  describe('illegal concurrent request error handling', () => {
+    beforeEach(() => {
+      spyOn(request, 'dispose').and.callThrough();
+    });
+
+    it('should listen to error and dispose', async function(done) {
+      let promise = request.getPromise();
+      let expectedError = OpenYoloError.illegalConcurrentRequestError();
+      providerChannel.send(errorMessage(request.id, expectedError));
+      try {
+        await promise;
+        done.fail('Promise should not resolve');
+      } catch (err) {
+        expect(err).toEqual(expectedError);
+        expect(request.dispose).toHaveBeenCalled();
+        expect(frame.hide).not.toHaveBeenCalled();
         done();
       }
     });

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -111,7 +111,7 @@ export class OpenYoloError {
   static illegalConcurrentRequestError() {
     return OpenYoloError.createError({
       code: ERROR_TYPES.illegalConcurrentRequest,
-      message: 'Concurrent requests are not authorized'
+      message: 'Concurrent requests are not permitted'
     });
   }
 

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -28,6 +28,7 @@ export const ERROR_TYPES = strEnum(
     'requestFailed',
     'requestTimeout',
     'illegalState',
+    'illegalConcurrentRequest',
     'establishSecureChannelTimeout',
     'unknownRequest',
     'apiDisabled',
@@ -105,6 +106,13 @@ export class OpenYoloError {
   static illegalStateError(reason: string) {
     return OpenYoloError.createError(
         {code: ERROR_TYPES.illegalState, message: reason});
+  }
+
+  static illegalConcurrentRequestError() {
+    return OpenYoloError.createError({
+      code: ERROR_TYPES.illegalConcurrentRequest,
+      message: 'Concurrent requests are not authorized'
+    });
   }
 
   static establishSecureChannelTimeout() {


### PR DESCRIPTION
Added a new type of error, `illegalConcurrentRequest`, to be able to distinguish in the client side whether to hide the IFrame or not.