### PR TITLE
Fallback to sending the un-hashed ID if insecure origin

### DIFF
--- a/ts/protocol/utils.ts
+++ b/ts/protocol/utils.ts
@@ -32,6 +32,8 @@ export function generateId(): string {
 /**
  * Returns the SHA-256 hash of the string given.
  * https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+ *
+ * TODO(tch): Find a better fallback mechanism.
  */
 export async function sha256(str: string): Promise<string> {
   // To avoid issues where crypto is not available, return the ID without
@@ -41,8 +43,13 @@ export async function sha256(str: string): Promise<string> {
   }
   // Transform the string into an arraybuffer.
   const buffer = encodeStringToBuffer(str);
-  const hash = await subtleCrypto.digest('SHA-256', buffer);
-  return hex(hash);
+  try {
+    const hash = await subtleCrypto.digest('SHA-256', buffer);
+    return hex(hash);
+  } catch (e) {
+    // Insecure origin error. Fallback to passing the un-hashed string.
+    return Promise.resolve(str);
+  }
 }
 
 function encodeStringToBuffer(str: string): ArrayBuffer {

--- a/ts/protocol/utils_test.ts
+++ b/ts/protocol/utils_test.ts
@@ -35,6 +35,7 @@ describe('utils', () => {
       expect(hash).toBeTruthy();
       done();
     });
+
     it('works without native TextEncoder', async function(done) {
       const textEncoderImpl = TextEncoder;
       delete (window as WindowWithTextEncoder).TextEncoder;
@@ -48,5 +49,14 @@ describe('utils', () => {
       }
       done();
     });
+
+    it('fallbacks to returning the string if insecure origin',
+       async function(done) {
+         spyOn(window.crypto.subtle, 'digest')
+             .and.throwError('Insecure Origin!');
+         const hash = await utils.sha256(str);
+         expect(hash).toEqual(str);
+         done();
+       });
   });
 });


### PR DESCRIPTION
For tests purpose, it is important to have a fallback mechanism if the webcrypto hashing fails with insecure origin error.