### PR TITLE
Allows disabling timeout from the client

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(karma) {
   var config = Object.assign(karma_base.baseConfig, {
     autoWatch: true,
     reporters: ['verbose', 'karma-typescript', 'coverage'],
-    coverageReporter: {type: 'json', dir: 'coverage/'},
+    coverageReporter: {type: 'html', dir: 'coverage/'},
     singleRun: true
   });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(karma) {
   var config = Object.assign(karma_base.baseConfig, {
     autoWatch: true,
     reporters: ['verbose', 'karma-typescript', 'coverage'],
-    coverageReporter: {type: 'lcov', dir: 'coverage/'},
+    coverageReporter: {type: 'json', dir: 'coverage/'},
     singleRun: true
   });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(karma) {
   var config = Object.assign(karma_base.baseConfig, {
     autoWatch: true,
     reporters: ['verbose', 'karma-typescript', 'coverage'],
-    coverageReporter: {type: 'html', dir: 'coverage/'},
+    coverageReporter: {type: 'json', subdir: '.', file: 'coverage-final.json'},
     singleRun: true
   });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,11 +22,13 @@ module.exports = function(karma) {
   var config = Object.assign(karma_base.baseConfig, {
     autoWatch: true,
     reporters: ['verbose', 'karma-typescript', 'coverage'],
-    coverageReporter: {type: 'json', subdir: '.', file: 'coverage-final.json'},
     singleRun: true
   });
 
   config.karmaTypescriptConfig.coverageOptions = {exclude: /_test\.ts$/};
+  config.karmaTypescriptConfig.reports = {
+    json: {filename: 'coverage-final.json'}
+  };
 
   if (process.argv.includes('--use-sauce')) {
     config.customLaunchers = saucelabs.browsers;

--- a/karma_base.js
+++ b/karma_base.js
@@ -25,7 +25,7 @@ exports.baseConfig = {
   concurrency: 1,
   files: ['ts/**/*.ts'],
   frameworks: ['jasmine', 'karma-typescript'],
-  karmaTypescriptConfig: {tsconfig: 'tsconfig-karma.json'},
+  karmaTypescriptConfig: {tsconfig: './tsconfig-karma.json'},
   port: 9876,
   preprocessors: {'**/*.ts': ['karma-typescript']},
   reporters: ['karma-typescript']

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "karma-cli": "~1.0.1",
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "karma-typescript": "beta",
+    "karma-typescript": "^3.0.0",
     "karma-verbose-reporter": "0.0.5",
     "pre-commit": "^1.2.2",
     "protractor": "~5.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "type-check": "./node_modules/.bin/tsc -p tsconfig.json --noemit",
     "test": "./node_modules/.bin/karma start",
     "test-debug": "./node_modules/.bin/karma start karma.debug.conf.js",
-    "codecov": "codecov",
+    "codecov": "./node_modules/.bin/codecov --file=coverage/coverage-final.json",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "check": "yarn run type-check && yarn run lint-all && yarn run test",
     "demo-client-apitester": "./node_modules/.bin/ng serve --app demo-client-apitester --port 4200",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "type-check": "./node_modules/.bin/tsc -p tsconfig.json --noemit",
     "test": "./node_modules/.bin/karma start",
     "test-debug": "./node_modules/.bin/karma start karma.debug.conf.js",
-    "codecov": "./node_modules/.bin/codecov --file=coverage/coverage-final.json",
+    "codecov": "for file in coverage/**/coverage-final.json; do ./node_modules/.bin/codecov --file=\"$file\"; done",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "check": "yarn run type-check && yarn run lint-all && yarn run test",
     "demo-client-apitester": "./node_modules/.bin/ng serve --app demo-client-apitester --port 4200",

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -187,15 +187,13 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
     // Check whether the client should wrap the browser's navigator.credentials.
     const request = new WrapBrowserRequest(frameManager, channel);
+    const timeoutMs =
+        areTimeoutsDisabled ? undefined : TIMEOUTS.wrapBrowserRequest;
     const wrapBrowser =
-        await request
-            .dispatch(
-                undefined,
-                areTimeoutsDisabled ? undefined : TIMEOUTS.wrapBrowserRequest)
-            .catch((error) => {
-              // Ignore timeout errors or other.
-              return false;
-            });
+        await request.dispatch(undefined, timeoutMs).catch((error) => {
+          // Ignore errors.
+          return false;
+        });
 
     return new OpenYoloApiImpl(
         frameManager, channel, wrapBrowser, areTimeoutsDisabled);
@@ -212,22 +210,20 @@ class OpenYoloApiImpl implements OpenYoloApi {
   async hintsAvailable(options: CredentialHintOptions): Promise<boolean> {
     this.checkNotDisposed();
     const request = new HintAvailableRequest(this.frameManager, this.channel);
-    return request
-        .dispatch(
-            options,
-            this.areTimeoutsDisabled ? undefined :
-                                       TIMEOUTS.hintAvailableRequest)
-        .catch((error) => {
-          // Ignore errors.
-          return false;
-        });
+    const timeoutMs =
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintAvailableRequest;
+    return request.dispatch(options, timeoutMs).catch((error) => {
+      // Ignore errors.
+      return false;
+    });
   }
 
   async hint(options: CredentialHintOptions): Promise<Credential> {
     this.checkNotDisposed();
     const request = new HintRequest(this.frameManager, this.channel);
-    return request.dispatch(
-        options, this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintRequest);
+    const timeoutMs =
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintRequest;
+    return request.dispatch(options, timeoutMs);
   }
 
   async retrieve(options: CredentialRequestOptions): Promise<Credential> {
@@ -248,9 +244,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
   private retrieveUsingChannel(options: CredentialRequestOptions):
       Promise<Credential> {
     const request = new CredentialRequest(this.frameManager, this.channel);
-    return request.dispatch(
-        options,
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialRequest);
+    const timeoutMs =
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialRequest;
+    return request.dispatch(options, timeoutMs);
   }
 
   async save(credential: Credential): Promise<void> {
@@ -269,9 +265,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
   private async saveUsingChannel(credential: Credential) {
     let request = new CredentialSave(this.frameManager, this.channel);
-    return request.dispatch(
-        credential,
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialSave);
+    const timeoutMs =
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialSave;
+    return request.dispatch(credential, timeoutMs);
   }
 
   async disableAutoSignIn(): Promise<void> {
@@ -324,8 +320,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
   private async proxyLoginUsingChannel(credential: Credential) {
     let request = new ProxyLogin(this.frameManager, this.channel);
-    return request.dispatch(
-        credential, this.areTimeoutsDisabled ? undefined : TIMEOUTS.proxyLogin);
+    const timeoutMs =
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.proxyLogin;
+    return request.dispatch(credential, timeoutMs);
   }
 }
 
@@ -346,11 +343,10 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
   private providerUrlBase: string = 'https://provider.openyolo.org';
   private implPromise: Promise<OpenYoloApiImpl> = null;
   private renderMode: RenderMode|null = null;
-  /** Prefer a default boolean value of false rather than true. */
   private areTimeoutsDisabled: boolean = false;
 
   constructor() {
-    // register the handler for ping verification automatically on module load
+    // Register the handler for ping verification automatically on module load.
     respondToHandshake(window);
   }
 

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -125,7 +125,7 @@ export interface OpenYoloApi {
 /**
  * Defines the different timeouts for every request.
  */
-const TIMEOUTS: {[key: string]: number} = {
+const DEFAULT_TIMEOUTS: {[key: string]: number} = {
   credentialRequest: 3000,
   credentialSave: 3000,
   hintAvailableRequest: 1000,
@@ -188,7 +188,7 @@ class OpenYoloApiImpl implements OpenYoloApi {
     // Check whether the client should wrap the browser's navigator.credentials.
     const request = new WrapBrowserRequest(frameManager, channel);
     const timeoutMs =
-        areTimeoutsDisabled ? undefined : TIMEOUTS.wrapBrowserRequest;
+        areTimeoutsDisabled ? undefined : DEFAULT_TIMEOUTS.wrapBrowserRequest;
     const wrapBrowser =
         await request.dispatch(undefined, timeoutMs).catch((error) => {
           // Ignore errors.
@@ -210,8 +210,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
   async hintsAvailable(options: CredentialHintOptions): Promise<boolean> {
     this.checkNotDisposed();
     const request = new HintAvailableRequest(this.frameManager, this.channel);
-    const timeoutMs =
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintAvailableRequest;
+    const timeoutMs = this.areTimeoutsDisabled ?
+        undefined :
+        DEFAULT_TIMEOUTS.hintAvailableRequest;
     return request.dispatch(options, timeoutMs).catch((error) => {
       // Ignore errors.
       return false;
@@ -222,7 +223,7 @@ class OpenYoloApiImpl implements OpenYoloApi {
     this.checkNotDisposed();
     const request = new HintRequest(this.frameManager, this.channel);
     const timeoutMs =
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintRequest;
+        this.areTimeoutsDisabled ? undefined : DEFAULT_TIMEOUTS.hintRequest;
     return request.dispatch(options, timeoutMs);
   }
 
@@ -244,8 +245,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
   private retrieveUsingChannel(options: CredentialRequestOptions):
       Promise<Credential> {
     const request = new CredentialRequest(this.frameManager, this.channel);
-    const timeoutMs =
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialRequest;
+    const timeoutMs = this.areTimeoutsDisabled ?
+        undefined :
+        DEFAULT_TIMEOUTS.credentialRequest;
     return request.dispatch(options, timeoutMs);
   }
 
@@ -266,7 +268,7 @@ class OpenYoloApiImpl implements OpenYoloApi {
   private async saveUsingChannel(credential: Credential) {
     let request = new CredentialSave(this.frameManager, this.channel);
     const timeoutMs =
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialSave;
+        this.areTimeoutsDisabled ? undefined : DEFAULT_TIMEOUTS.credentialSave;
     return request.dispatch(credential, timeoutMs);
   }
 
@@ -321,7 +323,7 @@ class OpenYoloApiImpl implements OpenYoloApi {
   private async proxyLoginUsingChannel(credential: Credential) {
     let request = new ProxyLogin(this.frameManager, this.channel);
     const timeoutMs =
-        this.areTimeoutsDisabled ? undefined : TIMEOUTS.proxyLogin;
+        this.areTimeoutsDisabled ? undefined : DEFAULT_TIMEOUTS.proxyLogin;
     return request.dispatch(credential, timeoutMs);
   }
 }
@@ -329,7 +331,7 @@ class OpenYoloApiImpl implements OpenYoloApi {
 export interface OnDemandOpenYoloApi extends OpenYoloApi {
   setProviderUrlBase(providerUrlBase: string): void;
   setRenderMode(renderMode: string): void;
-  enableTimeouts(enable: boolean): void;
+  setTimeoutsEnabled(enable: boolean): void;
   reset(): void;
 }
 
@@ -360,7 +362,7 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     this.reset();
   }
 
-  enableTimeouts(enable: boolean) {
+  setTimeoutsEnabled(enable: boolean) {
     this.areTimeoutsDisabled = !enable;
     this.reset();
   }

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -427,6 +427,8 @@ InitializeOnDemandApi.prototype['setProviderUrlBase'] =
     InitializeOnDemandApi.prototype.setProviderUrlBase;
 InitializeOnDemandApi.prototype['setRenderMode'] =
     InitializeOnDemandApi.prototype.setRenderMode;
+InitializeOnDemandApi.prototype['setTimeoutsEnabled'] =
+    InitializeOnDemandApi.prototype.setTimeoutsEnabled;
 InitializeOnDemandApi.prototype['hintsAvailable'] =
     InitializeOnDemandApi.prototype.hintsAvailable;
 InitializeOnDemandApi.prototype['hint'] = InitializeOnDemandApi.prototype.hint;

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -17,6 +17,7 @@
 import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
 import {RENDER_MODES, RenderMode} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
+import {PRELOAD_REQUEST, PreloadRequest} from '../protocol/preload_request';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, sha256} from '../protocol/utils';
 
@@ -26,13 +27,12 @@ import {HintAvailableRequest} from './hint_available_request';
 import {HintRequest} from './hint_request';
 import {ProviderFrameElement} from './provider_frame_elem';
 import {ProxyLogin} from './proxy_login';
+import {respondToHandshake} from './verify';
 import {WrapBrowserRequest} from './wrap_browser_request';
 
 // re-export all the data types
 export * from '../protocol/data';
 export {OpenYoloError, ERROR_TYPES} from '../protocol/errors';
-import {respondToHandshake} from './verify';
-import {PreloadRequest, PRELOAD_REQUEST} from '../protocol/preload_request';
 
 const MOBILE_USER_AGENT_REGEX = /android|iphone|ipod|iemobile/i;
 
@@ -123,6 +123,37 @@ export interface OpenYoloApi {
 }
 
 /**
+ * Defines the different timeouts for every request.
+ */
+const TIMEOUTS: {[key: string]: number} = {
+  credentialRequest: 3000,
+  credentialSave: 3000,
+  hintAvailableRequest: 1000,
+  hintRequest: 3000,
+  proxyLogin: 10000,
+  wrapBrowserRequest: 1000
+};
+
+/**
+ * Sanitzes the input for renderMode, selecting the default one if invalid.
+ */
+function verifyOrDetectRenderMode(renderMode?: RenderMode): RenderMode {
+  if (renderMode in RENDER_MODES) {
+    return renderMode;
+  }
+  const isNested = window.parent !== window;
+  if (isNested) {
+    return RENDER_MODES.fullScreen;
+  }
+  const isMobile = navigator.userAgent.match(MOBILE_USER_AGENT_REGEX);
+  if (isMobile) {
+    return RENDER_MODES.bottomSheet;
+  } else {
+    return RENDER_MODES.navPopout;
+  }
+}
+
+/**
  * Provides access to the user's preferred credential provider, in order to
  * retrieve credentials.
  */
@@ -130,23 +161,14 @@ class OpenYoloApiImpl implements OpenYoloApi {
   static async create(
       providerUrlBase: string,
       renderMode?: RenderMode,
+      areTimeoutsDisabled?: boolean,
       preloadRequest?: PreloadRequest): Promise<OpenYoloApiImpl> {
-    let instanceId = generateId();
-    let instanceIdHash = await sha256(instanceId);
+    // Sanitize input.
+    renderMode = verifyOrDetectRenderMode(renderMode);
 
-    if (!renderMode || !(renderMode in RENDER_MODES)) {
-      let isMobile = navigator.userAgent.match(MOBILE_USER_AGENT_REGEX);
-      let isNested = window.parent !== window;
-      if (isNested) {
-        renderMode = RENDER_MODES.fullScreen;
-      } else if (isMobile) {
-        renderMode = RENDER_MODES.bottomSheet;
-      } else {
-        renderMode = RENDER_MODES.navPopout;
-      }
-    }
-
-    let frameManager = new ProviderFrameElement(
+    const instanceId = generateId();
+    const instanceIdHash = await sha256(instanceId);
+    const frameManager = new ProviderFrameElement(
         document,
         instanceIdHash,
         window.location.origin,
@@ -154,16 +176,29 @@ class OpenYoloApiImpl implements OpenYoloApi {
         providerUrlBase,
         preloadRequest);
 
-    // TODO: the timeout must be split across multiple operations; might be
-    // better to race two promises to make this easier.
+    let channel: SecureChannel|null = null;
+    if (areTimeoutsDisabled) {
+      channel = await SecureChannel.clientConnectNoTimeout(
+          window, frameManager.getContentWindow(), instanceId, instanceIdHash);
+    } else {
+      channel = await SecureChannel.clientConnect(
+          window, frameManager.getContentWindow(), instanceId, instanceIdHash);
+    }
 
-    let channel = await SecureChannel.clientConnect(
-        window, frameManager.getContentWindow(), instanceId, instanceIdHash);
+    // Check whether the client should wrap the browser's navigator.credentials.
+    const request = new WrapBrowserRequest(frameManager, channel);
+    const wrapBrowser =
+        await request
+            .dispatch(
+                undefined,
+                areTimeoutsDisabled ? undefined : TIMEOUTS.wrapBrowserRequest)
+            .catch((error) => {
+              // Ignore timeout errors or other.
+              return false;
+            });
 
-    let request = new WrapBrowserRequest(frameManager, channel);
-    let wrapBrowser = await request.dispatch();
-
-    return new OpenYoloApiImpl(frameManager, channel, wrapBrowser);
+    return new OpenYoloApiImpl(
+        frameManager, channel, wrapBrowser, areTimeoutsDisabled);
   }
 
   private disposed: boolean = false;
@@ -171,20 +206,28 @@ class OpenYoloApiImpl implements OpenYoloApi {
   constructor(
       private frameManager: ProviderFrameElement,
       private channel: SecureChannel,
-      private wrapBrowser: boolean) {}
+      private wrapBrowser: boolean,
+      private areTimeoutsDisabled: boolean) {}
 
-  async hintsAvailable(options: CredentialHintOptions, timeoutMs?: number):
-      Promise<boolean> {
+  async hintsAvailable(options: CredentialHintOptions): Promise<boolean> {
     this.checkNotDisposed();
-    let request = new HintAvailableRequest(this.frameManager, this.channel);
-    return request.dispatch(options, timeoutMs);
+    const request = new HintAvailableRequest(this.frameManager, this.channel);
+    return request
+        .dispatch(
+            options,
+            this.areTimeoutsDisabled ? undefined :
+                                       TIMEOUTS.hintAvailableRequest)
+        .catch((error) => {
+          // Ignore errors.
+          return false;
+        });
   }
 
-  async hint(options: CredentialHintOptions, timeoutMs?: number):
-      Promise<Credential> {
+  async hint(options: CredentialHintOptions): Promise<Credential> {
     this.checkNotDisposed();
-    let request = new HintRequest(this.frameManager, this.channel);
-    return request.dispatch(options);
+    const request = new HintRequest(this.frameManager, this.channel);
+    return request.dispatch(
+        options, this.areTimeoutsDisabled ? undefined : TIMEOUTS.hintRequest);
   }
 
   async retrieve(options: CredentialRequestOptions): Promise<Credential> {
@@ -204,16 +247,18 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
   private retrieveUsingChannel(options: CredentialRequestOptions):
       Promise<Credential> {
-    let request = new CredentialRequest(this.frameManager, this.channel);
-    return request.dispatch(options);
+    const request = new CredentialRequest(this.frameManager, this.channel);
+    return request.dispatch(
+        options,
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialRequest);
   }
 
   async save(credential: Credential): Promise<void> {
     this.checkNotDisposed();
     if (this.wrapBrowser) {
-      this.saveUsingBrowser(credential);
+      return this.saveUsingBrowser(credential);
     } else {
-      this.saveUsingChannel(credential);
+      return this.saveUsingChannel(credential);
     }
   }
 
@@ -224,7 +269,9 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
   private async saveUsingChannel(credential: Credential) {
     let request = new CredentialSave(this.frameManager, this.channel);
-    return request.dispatch(credential);
+    return request.dispatch(
+        credential,
+        this.areTimeoutsDisabled ? undefined : TIMEOUTS.credentialSave);
   }
 
   async disableAutoSignIn(): Promise<void> {
@@ -277,13 +324,15 @@ class OpenYoloApiImpl implements OpenYoloApi {
 
   private async proxyLoginUsingChannel(credential: Credential) {
     let request = new ProxyLogin(this.frameManager, this.channel);
-    return request.dispatch(credential);
+    return request.dispatch(
+        credential, this.areTimeoutsDisabled ? undefined : TIMEOUTS.proxyLogin);
   }
 }
 
 export interface OnDemandOpenYoloApi extends OpenYoloApi {
   setProviderUrlBase(providerUrlBase: string): void;
   setRenderMode(renderMode: string): void;
+  enableTimeouts(enable: boolean): void;
   reset(): void;
 }
 
@@ -297,6 +346,8 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
   private providerUrlBase: string = 'https://provider.openyolo.org';
   private implPromise: Promise<OpenYoloApiImpl> = null;
   private renderMode: RenderMode|null = null;
+  /** Prefer a default boolean value of false rather than true. */
+  private areTimeoutsDisabled: boolean = false;
 
   constructor() {
     // register the handler for ping verification automatically on module load
@@ -310,6 +361,11 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
 
   setRenderMode(renderMode: RenderMode|null) {
     this.renderMode = renderMode;
+    this.reset();
+  }
+
+  enableTimeouts(enable: boolean) {
+    this.areTimeoutsDisabled = !enable;
     this.reset();
   }
 
@@ -329,7 +385,10 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
   private init(preloadRequest?: PreloadRequest) {
     if (!this.implPromise) {
       this.implPromise = OpenYoloApiImpl.create(
-          this.providerUrlBase, this.renderMode, preloadRequest);
+          this.providerUrlBase,
+          this.renderMode,
+          this.areTimeoutsDisabled,
+          preloadRequest);
     }
     return this.implPromise;
   }

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
+import {SecureChannel} from '../protocol/secure_channel';
+
+import {openyolo} from './api';
+import {CredentialRequest} from './credential_request';
+import {CredentialSave} from './credential_save';
+import {HintAvailableRequest} from './hint_available_request';
+import {HintRequest} from './hint_request';
+import {ProxyLogin} from './proxy_login';
+import {WrapBrowserRequest} from './wrap_browser_request';
+
+describe('OpenYolo API', () => {
+  const credential: Credential = {id: 'test', authMethod: 'test'};
+  const expectedError = new Error('ERROR!');
+  const secureChannelSpy = jasmine.createSpyObj('SecureChannel', ['send']);
+
+  describe('not wrapping browser', () => {
+    beforeEach(() => {
+      spyOn(WrapBrowserRequest.prototype, 'dispatch')
+          .and.returnValue(Promise.resolve(false));
+    });
+
+    describe('timeouts enabled', () => {
+      beforeEach(() => {
+        spyOn(SecureChannel, 'clientConnect')
+            .and.returnValue(Promise.resolve(secureChannelSpy));
+        spyOn(SecureChannel, 'clientConnectNoTimeout')
+            .and.throwError('Should not use the noTimeout method!');
+      });
+
+      describe('hintsAvailable', () => {
+        const options: CredentialHintOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(HintAvailableRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(true));
+          openyolo.hintsAvailable(options).then((result) => {
+            expect(result).toBe(true);
+            expect(HintAvailableRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, 1000);
+            done();
+          });
+        });
+
+        it('returns false when rejects', async function(done) {
+          spyOn(HintAvailableRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.reject(expectedError));
+          openyolo.hintsAvailable(options).then((result) => {
+            expect(result).toBe(false);
+            expect(HintAvailableRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, 1000);
+            done();
+          });
+        });
+      });
+
+      describe('hint', () => {
+        const options: CredentialHintOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(HintRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(credential));
+          openyolo.hint(options).then((result) => {
+            expect(result).toEqual(credential);
+            expect(HintRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, 3000);
+            done();
+          });
+        });
+
+        it('rejects', async function(done) {
+          spyOn(HintRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.reject(expectedError));
+          openyolo.hint(options).then(
+              () => {
+                done.fail('Should not succeed!');
+              },
+              (error) => {
+                expect(HintRequest.prototype.dispatch)
+                    .toHaveBeenCalledWith(options, 3000);
+                expect(error).toEqual(expectedError);
+                done();
+              });
+        });
+      });
+
+      describe('retrieve', () => {
+        const options: CredentialRequestOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(CredentialRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(credential));
+          openyolo.retrieve(options).then((result) => {
+            expect(result).toEqual(credential);
+            expect(CredentialRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, 3000);
+            done();
+          });
+        });
+
+        it('rejects', async function(done) {
+          spyOn(CredentialRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.reject(expectedError));
+          openyolo.retrieve(options).then(
+              () => {
+                done.fail('Should not succeed!');
+              },
+              (error) => {
+                expect(error).toEqual(expectedError);
+                expect(CredentialRequest.prototype.dispatch)
+                    .toHaveBeenCalledWith(options, 3000);
+                done();
+              });
+        });
+      });
+
+      describe('save', () => {
+        it('works', async function(done) {
+          spyOn(CredentialSave.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve());
+          openyolo.save(credential).then(() => {
+            expect(CredentialSave.prototype.dispatch)
+                .toHaveBeenCalledWith(credential, 3000);
+            done();
+          });
+        });
+
+        it('rejects', async function(done) {
+          spyOn(CredentialSave.prototype, 'dispatch')
+              .and.returnValue(Promise.reject(expectedError));
+          openyolo.save(credential)
+              .then(
+                  () => {
+                    done.fail('Should not succeed!');
+                  },
+                  (error) => {
+                    expect(error).toEqual(expectedError);
+                    expect(CredentialSave.prototype.dispatch)
+                        .toHaveBeenCalledWith(credential, 3000);
+                    done();
+                  });
+        });
+      });
+
+      describe('proxyLogin', () => {
+        it('works', async function(done) {
+          const expectedResponse:
+              ProxyLoginResponse = {statusCode: 200, responseText: 'test'};
+          spyOn(ProxyLogin.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(expectedResponse));
+          openyolo.proxyLogin(credential).then((result) => {
+            expect(result).toEqual(expectedResponse);
+            expect(ProxyLogin.prototype.dispatch)
+                .toHaveBeenCalledWith(credential, 10000);
+            done();
+          });
+        });
+
+        it('rejects', async function(done) {
+          spyOn(ProxyLogin.prototype, 'dispatch')
+              .and.returnValue(Promise.reject(expectedError));
+          openyolo.proxyLogin(credential)
+              .then(
+                  () => {
+                    done.fail('Should not succeed!');
+                  },
+                  (error) => {
+                    expect(error).toEqual(expectedError);
+                    expect(ProxyLogin.prototype.dispatch)
+                        .toHaveBeenCalledWith(credential, 10000);
+                    done();
+                  });
+        });
+      });
+    });
+
+    describe('timeouts disabled', () => {
+      beforeEach(() => {
+        spyOn(SecureChannel, 'clientConnect')
+            .and.throwError('Should not use the with timeout method!');
+        spyOn(SecureChannel, 'clientConnectNoTimeout')
+            .and.returnValue(Promise.resolve(secureChannelSpy));
+        openyolo.enableTimeouts(false);
+      });
+
+      describe('hintsAvailable', () => {
+        const options: CredentialHintOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(HintAvailableRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(true));
+          openyolo.hintsAvailable(options).then((result) => {
+            expect(result).toBe(true);
+            expect(HintAvailableRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, undefined);
+            done();
+          });
+        });
+      });
+
+      describe('hint', () => {
+        const options: CredentialHintOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(HintRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(credential));
+          openyolo.hint(options).then((result) => {
+            expect(result).toEqual(credential);
+            expect(HintRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, undefined);
+            done();
+          });
+        });
+      });
+
+      describe('retrieve', () => {
+        const options: CredentialRequestOptions = {supportedAuthMethods: []};
+
+        it('works', async function(done) {
+          spyOn(CredentialRequest.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(credential));
+          openyolo.retrieve(options).then((result) => {
+            expect(result).toEqual(credential);
+            expect(CredentialRequest.prototype.dispatch)
+                .toHaveBeenCalledWith(options, undefined);
+            done();
+          });
+        });
+      });
+
+      describe('save', () => {
+        it('works', async function(done) {
+          spyOn(CredentialSave.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve());
+          openyolo.save(credential).then(() => {
+            expect(CredentialSave.prototype.dispatch)
+                .toHaveBeenCalledWith(credential, undefined);
+            done();
+          });
+        });
+      });
+
+      describe('proxyLogin', () => {
+        it('works', async function(done) {
+          const expectedResponse:
+              ProxyLoginResponse = {statusCode: 200, responseText: 'test'};
+          spyOn(ProxyLogin.prototype, 'dispatch')
+              .and.returnValue(Promise.resolve(expectedResponse));
+          openyolo.proxyLogin(credential).then((result) => {
+            expect(result).toEqual(expectedResponse);
+            expect(ProxyLogin.prototype.dispatch)
+                .toHaveBeenCalledWith(credential, undefined);
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -196,7 +196,7 @@ describe('OpenYolo API', () => {
             .and.throwError('Should not use the with timeout method!');
         spyOn(SecureChannel, 'clientConnectNoTimeout')
             .and.returnValue(Promise.resolve(secureChannelSpy));
-        openyolo.enableTimeouts(false);
+        openyolo.setTimeoutsEnabled(false);
       });
 
       describe('hintsAvailable', () => {

--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -79,7 +79,7 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
    */
   private registerBaseHandlers(timeoutMs?: number) {
     this.debugLog('request instantiated');
-    // Register a standard error handler
+    // Register a standard error handler.
     this.registerHandler('error', (data: OpenYoloErrorData) => {
       let error: OpenYoloExtendedError;
       if (data) {

--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -110,11 +110,11 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
     }
   }
 
-  debugLog(message: string) {
+  protected debugLog(message: string) {
     console.debug(`(rq-${this.id}): ` + message);
   }
 
-  getPromise(): Promise<ResultT> {
+  protected getPromise(): Promise<ResultT> {
     return this.promiseResolver.promise;
   }
 

--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -141,10 +141,10 @@ describe('BaseRequest', () => {
 
     it('listens to error and disposes', async function(done) {
       const expectedError = OpenYoloError.illegalStateError('ERROR!');
-      request.dispatch(undefined);
+      const promise = request.dispatch(undefined);
       providerChannel.send(errorMessage(request.id, expectedError));
       try {
-        await request.getPromise();
+        await promise;
         done.fail('Promise should not resolve');
       } catch (err) {
         expect(err).toEqual(expectedError);
@@ -157,10 +157,10 @@ describe('BaseRequest', () => {
     it('listens to illegalConcurrentError and disposes but not hide the iframe',
        async function(done) {
          const expectedError = OpenYoloError.illegalConcurrentRequestError();
-         request.dispatch(undefined);
+         const promise = request.dispatch(undefined);
          providerChannel.send(errorMessage(request.id, expectedError));
          try {
-           await request.getPromise();
+           await promise;
            done.fail('Promise should not resolve');
          } catch (err) {
            expect(err).toEqual(expectedError);

--- a/ts/api/credential_request.ts
+++ b/ts/api/credential_request.ts
@@ -28,7 +28,7 @@ export class CredentialRequest extends
   /**
    * Starts the Credential Request flow.
    */
-  dispatchInternal(options: CredentialRequestOptions): Promise<Credential> {
+  dispatchInternal(options: CredentialRequestOptions) {
     // the final outcome will either be a credential, or a notification that
     // none are available / none was selected by the user.
     this.registerHandler(
@@ -38,7 +38,6 @@ export class CredentialRequest extends
 
     // send the request
     this.channel.send(retrieveMessage(this.id, options));
-    return this.getPromise();
   }
 
   /**

--- a/ts/api/credential_request.ts
+++ b/ts/api/credential_request.ts
@@ -15,12 +15,9 @@
  */
 
 import {Credential, CredentialRequestOptions} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
 import {retrieveMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
-
-const TIMEOUT_MS = 5000;
 
 /**
  * Handles the get credential request, by displaying the IFrame or not to let
@@ -31,21 +28,13 @@ export class CredentialRequest extends
   /**
    * Starts the Credential Request flow.
    */
-  dispatch(options?: CredentialRequestOptions): Promise<Credential> {
+  dispatchInternal(options: CredentialRequestOptions): Promise<Credential> {
     // the final outcome will either be a credential, or a notification that
     // none are available / none was selected by the user.
     this.registerHandler(
         RPC_MESSAGE_TYPES.credential,
         (credential: Credential) => this.handleResult(credential));
     this.registerHandler(RPC_MESSAGE_TYPES.none, () => this.handleResult(null));
-
-    // start our timeout, to ensure that if the provider takes too long to
-    // provide an initial response, that we do not indefinitely block the
-    // caller.
-    this.setAndRegisterTimeout(() => {
-      this.reject(OpenYoloError.requestTimeout());
-      this.dispose();
-    }, TIMEOUT_MS);
 
     // send the request
     this.channel.send(retrieveMessage(this.id, options));

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -21,7 +21,7 @@ import {RPC_MESSAGE_TYPES, saveMessage} from '../protocol/rpc_messages';
 import {BaseRequest} from './base_request';
 
 export class CredentialSave extends BaseRequest<void, Credential> {
-  dispatch(credential: Credential): Promise<void> {
+  dispatchInternal(credential: Credential): Promise<void> {
     this.registerHandler(RPC_MESSAGE_TYPES.saveResult, (saved: boolean) => {
       if (saved) {
         this.resolve();

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -21,7 +21,7 @@ import {RPC_MESSAGE_TYPES, saveMessage} from '../protocol/rpc_messages';
 import {BaseRequest} from './base_request';
 
 export class CredentialSave extends BaseRequest<void, Credential> {
-  dispatchInternal(credential: Credential): Promise<void> {
+  dispatchInternal(credential: Credential) {
     this.registerHandler(RPC_MESSAGE_TYPES.saveResult, (saved: boolean) => {
       if (saved) {
         this.resolve();
@@ -32,6 +32,5 @@ export class CredentialSave extends BaseRequest<void, Credential> {
     });
 
     this.channel.send(saveMessage(this.id, credential));
-    return this.getPromise();
   }
 }

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -21,7 +21,6 @@ import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_mess
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
 import {createSpyFrame} from '../test_utils/frames';
-import {JasmineTimeoutManager} from '../test_utils/timeout';
 
 import {CredentialSave} from './credential_save';
 
@@ -30,7 +29,6 @@ describe('CredentialSave', () => {
   let providerChannel: SecureChannel;
   let request: CredentialSave;
   let frame: any;
-  let timeoutManager = new JasmineTimeoutManager();
   let credential: Credential = {
     id: 'user@example.com',
     authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
@@ -45,12 +43,10 @@ describe('CredentialSave', () => {
     frame = createSpyFrame('frameId');
     request = new CredentialSave(frame, clientChannel);
     spyOn(request, 'dispose').and.callThrough();
-    timeoutManager.install();
   });
 
   afterEach(() => {
     request.dispose();
-    timeoutManager.uninstall();
   });
 
   describe('dispatch', () => {

--- a/ts/api/hint_available_request.ts
+++ b/ts/api/hint_available_request.ts
@@ -28,7 +28,7 @@ export class HintAvailableRequest extends
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatchInternal(options: CredentialHintOptions): Promise<boolean> {
+  dispatchInternal(options: CredentialHintOptions) {
     this.registerHandler(
         RPC_MESSAGE_TYPES.hintAvailableResult, (available: boolean) => {
           this.clearTimeouts();
@@ -37,6 +37,5 @@ export class HintAvailableRequest extends
         });
 
     this.channel.send(hintAvailableMessage(this.id, options));
-    return this.getPromise();
   }
 }

--- a/ts/api/hint_available_request.ts
+++ b/ts/api/hint_available_request.ts
@@ -19,8 +19,6 @@ import {hintAvailableMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages'
 
 import {BaseRequest} from './base_request';
 
-const DEFAULT_TIMEOUT_MS = 1000;
-
 /**
  * Handles the check for whether hints are available or not. It does not require
  * any user interaction, and if fails, just return as if there was no hints.
@@ -30,19 +28,13 @@ export class HintAvailableRequest extends
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatch(options: CredentialHintOptions, timeoutMs?: number):
-      Promise<boolean> {
+  dispatchInternal(options: CredentialHintOptions): Promise<boolean> {
     this.registerHandler(
         RPC_MESSAGE_TYPES.hintAvailableResult, (available: boolean) => {
           this.clearTimeouts();
           this.resolve(available);
           this.dispose();
         });
-
-    this.setAndRegisterTimeout(() => {
-      this.resolve(false);
-      this.dispose();
-    }, (timeoutMs && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS);
 
     this.channel.send(hintAvailableMessage(this.id, options));
     return this.getPromise();

--- a/ts/api/hint_available_request_test.ts
+++ b/ts/api/hint_available_request_test.ts
@@ -20,7 +20,6 @@ import {errorMessage, hintAvailableMessage, hintAvailableResponseMessage} from '
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
 import {createSpyFrame} from '../test_utils/frames';
-import {JasmineTimeoutManager} from '../test_utils/timeout';
 
 import {HintAvailableRequest} from './hint_available_request';
 
@@ -29,7 +28,6 @@ describe('HintAvailableRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let timeoutManager = new JasmineTimeoutManager();
   let passwordOnlyOptions: CredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
@@ -41,23 +39,13 @@ describe('HintAvailableRequest', () => {
     frame = createSpyFrame('frameId');
     request = new HintAvailableRequest(frame, clientChannel);
     spyOn(request, 'dispose').and.callThrough();
-    timeoutManager.install();
   });
 
   afterEach(() => {
     request.dispose();
-    timeoutManager.uninstall();
   });
 
   describe('dispatch', () => {
-    it('should timeout in 1 sec and resolve with false', done => {
-      request.dispatch(passwordOnlyOptions).then(result => {
-        expect(result).toBe(false);
-        done();
-      });
-      jasmine.clock().tick(1001);
-    });
-
     it('should send a RPC message to the frame', () => {
       spyOn(clientChannel, 'send').and.callThrough();
       request.dispatch(passwordOnlyOptions);

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -15,12 +15,9 @@
  */
 
 import {Credential, CredentialHintOptions} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
 import {hintMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
-
-const TIMEOUT_MS = 5000;
 
 /**
  * Handles the get hint request, by displaying the IFrame or not to let
@@ -31,16 +28,11 @@ export class HintRequest extends
   /**
    * Starts the Hint Request flow.
    */
-  dispatch(options: CredentialHintOptions): Promise<Credential> {
+  dispatchInternal(options: CredentialHintOptions): Promise<Credential> {
     this.registerHandler(
         RPC_MESSAGE_TYPES.credential,
         (credential: Credential) => this.handleResult(credential));
     this.registerHandler(RPC_MESSAGE_TYPES.none, () => this.handleResult(null));
-
-    this.setAndRegisterTimeout(() => {
-      this.reject(OpenYoloError.requestTimeout());
-      this.dispose();
-    }, TIMEOUT_MS);
 
     this.debugLog(`Sending hint request`);
     this.channel.send(hintMessage(this.id, options));

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -28,7 +28,7 @@ export class HintRequest extends
   /**
    * Starts the Hint Request flow.
    */
-  dispatchInternal(options: CredentialHintOptions): Promise<Credential> {
+  dispatchInternal(options: CredentialHintOptions) {
     this.registerHandler(
         RPC_MESSAGE_TYPES.credential,
         (credential: Credential) => this.handleResult(credential));
@@ -36,7 +36,6 @@ export class HintRequest extends
 
     this.debugLog(`Sending hint request`);
     this.channel.send(hintMessage(this.id, options));
-    return this.getPromise();
   }
 
   /**

--- a/ts/api/hint_request_test.ts
+++ b/ts/api/hint_request_test.ts
@@ -19,7 +19,6 @@ import {credentialResultMessage, hintMessage, noneAvailableMessage, showProvider
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
 import {createSpyFrame} from '../test_utils/frames';
-import {JasmineTimeoutManager} from '../test_utils/timeout';
 
 import {HintRequest} from './hint_request';
 
@@ -29,7 +28,6 @@ describe('HintRequest', () => {
   let providerChannel: SecureChannel;
   let frame: any;
   let hint: Credential;
-  let timeoutManager = new JasmineTimeoutManager();
   let passwordOnlyOptions: CredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
@@ -47,21 +45,13 @@ describe('HintRequest', () => {
       password: 'qwertyui'
     };
     spyOn(request, 'dispose').and.callThrough();
-    timeoutManager.install();
   });
 
   afterEach(() => {
     request.dispose();
-    timeoutManager.uninstall();
   });
 
   describe('dispatch', () => {
-    it('should timeout in 5 sec', done => {
-      request.dispatch(passwordOnlyOptions)
-          .then(() => done.fail(), () => done());
-      jasmine.clock().tick(5001);
-    });
-
     it('should send a RPC message to the frame', () => {
       spyOn(clientChannel, 'send').and.callThrough();
       let options: CredentialHintOptions = {

--- a/ts/api/proxy_login.ts
+++ b/ts/api/proxy_login.ts
@@ -26,7 +26,7 @@ export class ProxyLogin extends BaseRequest<ProxyLoginResponse, Credential> {
   /**
    * Starts the Proxy Login flow.
    */
-  dispatchInternal(credential: Credential): Promise<ProxyLoginResponse> {
+  dispatchInternal(credential: Credential) {
     this.registerHandler(
         RPC_MESSAGE_TYPES.proxyResult, (response: ProxyLoginResponse) => {
           this.resolve(response);
@@ -34,6 +34,5 @@ export class ProxyLogin extends BaseRequest<ProxyLoginResponse, Credential> {
         });
 
     this.channel.send(proxyLoginMessage(this.id, credential));
-    return this.getPromise();
   }
 }

--- a/ts/api/proxy_login.ts
+++ b/ts/api/proxy_login.ts
@@ -15,12 +15,9 @@
  */
 
 import {Credential, ProxyLoginResponse} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
 import {proxyLoginMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
-
-const TIMEOUT_MS = 10000;
 
 /**
  * Handles the proxy login.
@@ -29,16 +26,12 @@ export class ProxyLogin extends BaseRequest<ProxyLoginResponse, Credential> {
   /**
    * Starts the Proxy Login flow.
    */
-  dispatch(credential: Credential): Promise<ProxyLoginResponse> {
+  dispatchInternal(credential: Credential): Promise<ProxyLoginResponse> {
     this.registerHandler(
         RPC_MESSAGE_TYPES.proxyResult, (response: ProxyLoginResponse) => {
           this.resolve(response);
           this.dispose();
         });
-    this.setAndRegisterTimeout(() => {
-      this.reject(OpenYoloError.requestTimeout());
-      this.dispose();
-    }, TIMEOUT_MS);
 
     this.channel.send(proxyLoginMessage(this.id, credential));
     return this.getPromise();

--- a/ts/api/proxy_login_test.ts
+++ b/ts/api/proxy_login_test.ts
@@ -20,7 +20,6 @@ import {errorMessage, proxyLoginMessage, proxyLoginResponseMessage} from '../pro
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
 import {createSpyFrame} from '../test_utils/frames';
-import {JasmineTimeoutManager} from '../test_utils/timeout';
 
 import {ProxyLogin} from './proxy_login';
 
@@ -29,7 +28,6 @@ describe('ProxyLogin', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let timeoutManager = new JasmineTimeoutManager();
   let credential: Credential = {
     id: 'user@example.com',
     displayName: 'User',
@@ -46,17 +44,10 @@ describe('ProxyLogin', () => {
     frame = createSpyFrame('frameId');
     request = new ProxyLogin(frame, clientChannel);
     spyOn(request, 'dispose').and.callThrough();
-    timeoutManager.install();
   });
 
   afterEach(() => {
     request.dispose();
-    timeoutManager.uninstall();
-  });
-
-  it('sets a 10 sec timeout', done => {
-    request.dispatch(credential).then(() => done.fail(), () => done());
-    jasmine.clock().tick(10001);
   });
 
   describe('dispatch', () => {

--- a/ts/api/wrap_browser_request.ts
+++ b/ts/api/wrap_browser_request.ts
@@ -18,28 +18,21 @@ import {RPC_MESSAGE_TYPES, wrapBrowserMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
-const DEFAULT_TIMEOUT_MS = 1000;
-
 /**
- * Handles the check for whether hints are available or not. It does not require
- * any user interaction, and if fails, just return as if there was no hints.
+ * Handles the check for whether the browser navigator.credentials should be
+ * used in some flows.
  */
 export class WrapBrowserRequest extends BaseRequest<boolean, undefined> {
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatch(timeoutMs?: number): Promise<boolean> {
+  dispatchInternal(): Promise<boolean> {
     this.registerHandler(
         RPC_MESSAGE_TYPES.wrapBrowserResult, (wrapBrowser: boolean) => {
           this.clearTimeouts();
           this.resolve(wrapBrowser);
           this.dispose();
         });
-
-    this.setAndRegisterTimeout(() => {
-      this.resolve(false);
-      this.dispose();
-    }, (timeoutMs && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS);
 
     this.channel.send(wrapBrowserMessage(this.id));
     return this.getPromise();

--- a/ts/api/wrap_browser_request.ts
+++ b/ts/api/wrap_browser_request.ts
@@ -26,7 +26,7 @@ export class WrapBrowserRequest extends BaseRequest<boolean, undefined> {
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatchInternal(): Promise<boolean> {
+  dispatchInternal() {
     this.registerHandler(
         RPC_MESSAGE_TYPES.wrapBrowserResult, (wrapBrowser: boolean) => {
           this.clearTimeouts();
@@ -35,6 +35,5 @@ export class WrapBrowserRequest extends BaseRequest<boolean, undefined> {
         });
 
     this.channel.send(wrapBrowserMessage(this.id));
-    return this.getPromise();
   }
 }

--- a/ts/protocol/secure_channel.ts
+++ b/ts/protocol/secure_channel.ts
@@ -18,7 +18,7 @@ import {createMessageListener, FilteringEventListener, isPermittedOrigin, RpcMes
 import {OpenYoloError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, POST_MESSAGE_TYPES, readyForConnectMessage} from './post_messages';
 import {RpcMessage, RpcMessageDataTypes, RpcMessageType} from './rpc_messages';
-import {PromiseResolver, sha256, timeoutPromise, TimeoutPromiseResolver} from './utils';
+import {PromiseResolver, sha256, timeoutPromise} from './utils';
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
@@ -145,12 +145,9 @@ export class SecureChannel {
   static async providerConnect(
       providerWindow: WindowLike,
       permittedOrigins: string[],
-      connectionNonce: string,
-      timeoutMs?: number): Promise<SecureChannel> {
+      connectionNonce: string): Promise<SecureChannel> {
     let port: MessagePort|null = null;
-    let promiseResolver = new TimeoutPromiseResolver<SecureChannel>(
-        OpenYoloError.establishSecureChannelTimeout(),
-        (timeoutMs && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS);
+    let promiseResolver = new PromiseResolver<SecureChannel>();
 
     let listener = createMessageListener(
         'channelConnect', async function(nonce: string, type, ev) {

--- a/ts/protocol/secure_channel_test.ts
+++ b/ts/protocol/secure_channel_test.ts
@@ -249,33 +249,6 @@ describe('SecureChannel', () => {
       }
     });
 
-    it('times out if no message received', (done) => {
-      let expectFailNow = false;
-
-      // time out after 100ms
-      SecureChannel
-          .providerConnect(providerWindow, permittedOrigins, hashId, 100)
-          .then(
-              () => {
-                done.fail('Connection should not establish');
-              },
-              (err) => {
-                expect(expectFailNow)
-                    .toBeTruthy('Connection establishment prematurely failed');
-                expect(OpenYoloError.errorIs(
-                           err, ERROR_TYPES.establishSecureChannelTimeout))
-                    .toBeTruthy();
-                done();
-              });
-
-      // push the clock to right before the timeout
-      jasmine.clock().tick(90);
-
-      // ... and then over the threshold
-      expectFailNow = true;
-      jasmine.clock().tick(10);
-    });
-
     it('rejects if invalid origin', async function(done) {
       let evilOrigin = 'https://evil.example.com';
       let connectPromise = SecureChannel.providerConnect(

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -43,9 +43,8 @@ export class ProviderFrame {
    * Performs the initial validation of the execution context, and then
    * instantiates a {@link ProviderFrame} instance.
    */
-  static async initialize(
-      providerConfig: ProviderConfiguration,
-      establishTimeoutMs?: number): Promise<ProviderFrame> {
+  static async initialize(providerConfig: ProviderConfiguration):
+      Promise<ProviderFrame> {
     let secureChannel: SecureChannel|null;
     try {
       // fetch the client configuration, and ensure that the API is explicitly
@@ -80,8 +79,7 @@ export class ProviderFrame {
       secureChannel = await SecureChannel.providerConnect(
           providerConfig.window,
           [providerConfig.clientAuthDomain],
-          providerConfig.clientNonce,
-          establishTimeoutMs);
+          providerConfig.clientNonce);
 
       // success! create the frame manager to handle subsequent requests
       return new ProviderFrame(

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,13 +157,6 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@types/webappsec-credential-management/-/webappsec-credential-management-0.2.0.tgz#c84fe1ee14aefcae1d80e1fe77cff91e0b06e9c3"
 
-JSONStream@^1.0.3:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -332,10 +325,6 @@ array-differ@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -343,14 +332,6 @@ array-find-index@^1.0.1:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-slice@^0.2.3:
   version "0.2.3"
@@ -402,7 +383,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1, assert@^1.4.0:
+assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -413,12 +394,6 @@ assert@~1.3.0:
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.3.0.tgz#03939a622582a812cc202320a0b9a56c9b815849"
   dependencies:
     util "0.10.3"
-
-astw@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/astw/-/astw-2.2.0.tgz#7bd41784d32493987aeb239b6b4e1c57a873b917"
-  dependencies:
-    acorn "^4.0.3"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -690,17 +665,7 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-pack@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/browser-pack/-/browser-pack-6.0.2.tgz#f86cd6cef4f5300c8e63e07a4d512f65fbff4531"
-  dependencies:
-    JSONStream "^1.0.3"
-    combine-source-map "~0.7.1"
-    defined "^1.0.0"
-    through2 "^2.0.0"
-    umd "^3.0.0"
-
-browser-resolve@^1.11.0, browser-resolve@^1.7.0:
+browser-resolve@^1.11.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
   dependencies:
@@ -757,58 +722,6 @@ browserify-zlib@^0.1.4, browserify-zlib@~0.1.2:
   dependencies:
     pako "~0.2.0"
 
-browserify@^13.1.1:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-13.3.0.tgz#b5a9c9020243f0c70e4675bec8223bc627e415ce"
-  dependencies:
-    JSONStream "^1.0.3"
-    assert "^1.4.0"
-    browser-pack "^6.0.1"
-    browser-resolve "^1.11.0"
-    browserify-zlib "~0.1.2"
-    buffer "^4.1.0"
-    cached-path-relative "^1.0.0"
-    concat-stream "~1.5.1"
-    console-browserify "^1.1.0"
-    constants-browserify "~1.0.0"
-    crypto-browserify "^3.0.0"
-    defined "^1.0.0"
-    deps-sort "^2.0.0"
-    domain-browser "~1.1.0"
-    duplexer2 "~0.1.2"
-    events "~1.1.0"
-    glob "^7.1.0"
-    has "^1.0.0"
-    htmlescape "^1.1.0"
-    https-browserify "~0.0.0"
-    inherits "~2.0.1"
-    insert-module-globals "^7.0.0"
-    labeled-stream-splicer "^2.0.0"
-    module-deps "^4.0.8"
-    os-browserify "~0.1.1"
-    parents "^1.0.1"
-    path-browserify "~0.0.0"
-    process "~0.11.0"
-    punycode "^1.3.2"
-    querystring-es3 "~0.2.0"
-    read-only-stream "^2.0.0"
-    readable-stream "^2.0.2"
-    resolve "^1.1.4"
-    shasum "^1.0.0"
-    shell-quote "^1.6.1"
-    stream-browserify "^2.0.0"
-    stream-http "^2.0.0"
-    string_decoder "~0.10.0"
-    subarg "^1.0.0"
-    syntax-error "^1.1.1"
-    through2 "^2.0.0"
-    timers-browserify "^1.0.1"
-    tty-browserify "~0.0.0"
-    url "~0.11.0"
-    util "~0.10.1"
-    vm-browserify "~0.0.1"
-    xtend "^4.0.0"
-
 browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
@@ -851,10 +764,6 @@ bytes@2.3.0:
 bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
-
-cached-path-relative@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.1.tgz#d09c4b52800aa4c078e2dd81a869aac90d2e54e7"
 
 callsite@1.0.0:
   version "1.0.0"
@@ -1116,15 +1025,6 @@ combine-lists@^1.0.0:
   dependencies:
     lodash "^4.5.0"
 
-combine-source-map@~0.7.1:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/combine-source-map/-/combine-source-map-0.7.2.tgz#0870312856b307a87cc4ac486f3a9a62aeccc09e"
-  dependencies:
-    convert-source-map "~1.1.0"
-    inline-source-map "~0.6.0"
-    lodash.memoize "~3.0.3"
-    source-map "~0.5.3"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1193,7 +1093,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7, concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.4.7:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -1250,10 +1150,6 @@ content-type@~1.0.2:
 convert-source-map@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
-
-convert-source-map@~1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1494,6 +1390,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-format@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-0.0.0.tgz#09206863ab070eb459acea5542cbd856b11966b3"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1534,6 +1434,10 @@ debug@2.6.3:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
+
+debug@^0.7.2:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -1579,15 +1483,6 @@ depd@1.1.0, depd@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
 
-deps-sort@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/deps-sort/-/deps-sort-2.0.0.tgz#091724902e84658260eb910748cccd1af6e21fb5"
-  dependencies:
-    JSONStream "^1.0.3"
-    shasum "^1.0.0"
-    subarg "^1.0.0"
-    through2 "^2.0.0"
-
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -1604,13 +1499,6 @@ detect-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
-
-detective@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.5.0.tgz#6e5a8c6b26e6c7a254b1c6b6d7490d98ec91edd1"
-  dependencies:
-    acorn "^4.0.3"
-    defined "^1.0.0"
 
 di@^0.0.1:
   version "0.0.1"
@@ -1700,12 +1588,6 @@ duplexer2@0.0.2:
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
   dependencies:
     readable-stream "~1.1.9"
-
-duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -1868,10 +1750,6 @@ escodegen@1.8.x:
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-
-esprima@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 estraverse@^1.9.1:
   version "1.9.3"
@@ -2274,7 +2152,7 @@ glob@^5.0.14, glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2460,7 +2338,7 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has@^1.0.0, has@^1.0.1:
+has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
@@ -2541,10 +2419,6 @@ html-webpack-plugin@^2.19.0:
     lodash "^4.17.3"
     pretty-error "^2.0.2"
     toposort "^1.0.0"
-
-htmlescape@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
 
 htmlparser2@~3.3.0:
   version "3.3.0"
@@ -2679,12 +2553,6 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inline-source-map@~0.6.0:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
-  dependencies:
-    source-map "~0.5.3"
-
 inquirer@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
@@ -2702,19 +2570,6 @@ inquirer@^3.0.0:
     string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
-
-insert-module-globals@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.0.1.tgz#c03bf4e01cb086d5b5e5ace8ad0afe7889d638c3"
-  dependencies:
-    JSONStream "^1.0.3"
-    combine-source-map "~0.7.1"
-    concat-stream "~1.5.1"
-    is-buffer "^1.1.0"
-    lexical-scope "^1.2.0"
-    process "~0.11.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
 
 interpret@^1.0.0:
   version "1.0.3"
@@ -2748,7 +2603,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.0, is-buffer@^1.1.5:
+is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
@@ -2907,7 +2762,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-isarray@0.0.1, isarray@~0.0.1:
+isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
@@ -3017,14 +2872,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.x, js-yaml@^3.4.3:
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^3.1.1"
-
-js-yaml@~3.7.0:
+js-yaml@3.x, js-yaml@^3.4.3, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -3057,12 +2905,6 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stable-stringify@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3084,10 +2926,6 @@ jsonfile@^2.1.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonparse@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.0.tgz#85fc245b1d9259acc6941960b905adf64e7de0e8"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -3158,16 +2996,16 @@ karma-sourcemap-loader@^0.3.7:
   dependencies:
     graceful-fs "^4.1.2"
 
-karma-typescript@beta:
-  version "3.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/karma-typescript/-/karma-typescript-3.0.0-beta.2.tgz#f5c59a9dd647426f488ac46f4cc944805284f005"
+karma-typescript@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/karma-typescript/-/karma-typescript-3.0.2.tgz#992a62bec1cd48131dbe022fd01ea19a0338b090"
   dependencies:
     acorn "^4.0.4"
     amdefine "1.0.0"
     assert "~1.3.0"
     async "^2.1.4"
+    base64-js "^1.0.2"
     browser-resolve "^1.11.0"
-    browserify "^13.1.1"
     browserify-zlib "~0.1.2"
     buffer "^4.1.0"
     console-browserify "^1.1.0"
@@ -3180,9 +3018,12 @@ karma-typescript@beta:
     glob "^7.1.1"
     gulp-util "3.0.7"
     https-browserify "~0.0.0"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
     istanbul "0.4.5"
     karma-coverage "^1.1.1"
     lodash "^4.17.4"
+    log4js "^1.1.1"
     magic-string "^0.19.0"
     minimatch "^3.0.3"
     os-browserify "~0.1.1"
@@ -3265,14 +3106,6 @@ kind-of@^3.0.2:
   dependencies:
     is-buffer "^1.1.5"
 
-labeled-stream-splicer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz#a52e1d138024c00b86b1c0c91f677918b8ae0a59"
-  dependencies:
-    inherits "^2.0.1"
-    isarray "~0.0.1"
-    stream-splicer "^2.0.0"
-
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -3330,12 +3163,6 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lexical-scope@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
-  dependencies:
-    astw "^2.0.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -3442,10 +3269,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.memoize@~3.0.3:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
-
 lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
@@ -3509,6 +3332,14 @@ log4js@^0.6.31:
   dependencies:
     readable-stream "~1.0.2"
     semver "~4.3.3"
+
+log4js@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-1.1.1.tgz#c21d29c7604089e4f255833e7f94b3461de1ff43"
+  dependencies:
+    debug "^2.2.0"
+    semver "^5.3.0"
+    streamroller "^0.4.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3701,26 +3532,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-module-deps@^4.0.8:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.1.1.tgz#23215833f1da13fd606ccb8087b44852dcb821fd"
-  dependencies:
-    JSONStream "^1.0.3"
-    browser-resolve "^1.7.0"
-    cached-path-relative "^1.0.0"
-    concat-stream "~1.5.0"
-    defined "^1.0.0"
-    detective "^4.0.0"
-    duplexer2 "^0.1.2"
-    inherits "^2.0.1"
-    parents "^1.0.0"
-    readable-stream "^2.0.2"
-    resolve "^1.1.3"
-    stream-combiner2 "^1.1.1"
-    subarg "^1.0.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
 
 ms@0.7.1:
   version "0.7.1"
@@ -4075,12 +3886,6 @@ param-case@2.1.x:
   dependencies:
     no-case "^2.2.0"
 
-parents@^1.0.0, parents@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
-  dependencies:
-    path-platform "~0.11.15"
-
 parse-asn1@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
@@ -4153,10 +3958,6 @@ path-key@^1.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
-
-path-platform@~0.11.15:
-  version "0.11.15"
-  resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -4653,12 +4454,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-only-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
-  dependencies:
-    readable-stream "^2.0.2"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -4683,6 +4478,15 @@ readable-stream@1.0, readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@^1.1.7, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
@@ -4694,15 +4498,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
-
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@~2.0.0:
   version "2.0.6"
@@ -4921,7 +4716,7 @@ resolve@1.1.7, resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7:
+resolve@^1.1.6, resolve@^1.1.7:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -5164,7 +4959,7 @@ setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
-sha.js@^2.3.6, sha.js@~2.4.4:
+sha.js@^2.3.6:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
@@ -5179,13 +4974,6 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
-shasum@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"
-  dependencies:
-    json-stable-stringify "~0.0.0"
-    sha.js "~2.4.4"
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -5195,15 +4983,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shell-quote@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
 
 sigmund@^1.0.1:
   version "1.0.1"
@@ -5422,13 +5201,6 @@ stream-browserify@^2.0.0, stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-combiner2@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
-  dependencies:
-    duplexer2 "~0.1.0"
-    readable-stream "^2.0.2"
-
 stream-http@^2.0.0, stream-http@^2.3.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.0.tgz#cec1f4e3b494bc4a81b451808970f8b20b4ed5f6"
@@ -5439,12 +5211,14 @@ stream-http@^2.0.0, stream-http@^2.3.1:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-splicer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-2.0.0.tgz#1b63be438a133e4b671cc1935197600175910d83"
+streamroller@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-0.4.1.tgz#d435bd5974373abd9bd9068359513085106cc05f"
   dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
+    date-format "^0.0.0"
+    debug "^0.7.2"
+    mkdirp "^0.5.1"
+    readable-stream "^1.1.7"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -5530,12 +5304,6 @@ stylus@^0.54.5:
     sax "0.5.x"
     source-map "0.1.x"
 
-subarg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
-  dependencies:
-    minimist "^1.1.0"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -5561,12 +5329,6 @@ svgo@^0.7.0:
 symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
-
-syntax-error@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.3.0.tgz#1ed9266c4d40be75dc55bf9bb1cb77062bb96ca1"
-  dependencies:
-    acorn "^4.0.3"
 
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
@@ -5622,7 +5384,7 @@ through2@2.0.1, through2@^2.0.0, through2@^2.0.1:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-"through@>=2.2.7 <3", through@X.X.X, through@^2.3.6:
+through@X.X.X, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5838,10 +5600,6 @@ uid-number@^0.0.6:
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
-
-umd@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
 
 underscore.string@3.3.4:
   version "3.3.4"


### PR DESCRIPTION
- Refactored timeout handling for `Request`s to be able to set them at the dispatch time.
- Added an `enableTimeouts` method on the `openyolo` instance to enable/disable globally timeouts.
- Removed timeout from the `SecureChannel` on the provider side.
- Wrote tests to cover `api.ts`