### PR TITLE
Upgraded to TS 2.4 and refactored some tests

### DIFF
--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
+import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
 import {RenderMode} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import {PreloadRequest, PreloadRequestType} from '../protocol/preload_request';
@@ -56,7 +56,7 @@ export interface OpenYoloApi {
    *     and resolves with false if none are available. The promise will not
    *     reject: if an error happen, it should resolve with false.
    */
-  hintsAvailable(options: CredentialHintOptions): Promise<boolean>;
+  hintsAvailable(options: OYCredentialHintOptions): Promise<boolean>;
 
   /**
    * Attempts to retrieve a sign-up hint that can be used to create a new
@@ -70,7 +70,7 @@ export interface OpenYoloApi {
    *     A promise for a credential hint. The promise will be rejected if the
    *     user cancels the hint selection process.
    */
-  hint(options: CredentialHintOptions): Promise<Credential|null>;
+  hint(options: OYCredentialHintOptions): Promise<OYCredential|null>;
 
   /**
    * Attempts to retrieve a credential for the current origin.
@@ -83,7 +83,7 @@ export interface OpenYoloApi {
    *     Otherwise, the promise will resolve with a credential that the app
    *     can use.
    */
-  retrieve(options: CredentialRequestOptions): Promise<Credential|null>;
+  retrieve(options: OYCredentialRequestOptions): Promise<OYCredential|null>;
 
   /**
    * Attempts to save the provided credential, which will update or create
@@ -96,7 +96,7 @@ export interface OpenYoloApi {
    *     resolve, and does not indicate whether the credential was actually
    *     saved.
    */
-  save(credential: Credential): Promise<void>;
+  save(credential: OYCredential): Promise<void>;
 
   /**
    * Prevents the automatic release of a credential from the retrieve operation.
@@ -121,7 +121,7 @@ export interface OpenYoloApi {
    * @return
    *    A promise for the response data from the authentication system.
    */
-  proxyLogin(credential: Credential): Promise<ProxyLoginResponse>;
+  proxyLogin(credential: OYCredential): Promise<OYProxyLoginResponse>;
 
   /**
    * Cancels the last pending OpenYOLO request.
@@ -133,16 +133,16 @@ export interface OpenYoloApi {
  * A variant of the OpenYoloApi interface, with support for operation timeouts.
  */
 export interface OpenYoloWithTimeoutApi {
-  hintsAvailable(options: CredentialHintOptions, timeoutRacer: TimeoutRacer):
+  hintsAvailable(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
       Promise<boolean>;
-  hint(options: CredentialHintOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null>;
-  retrieve(options: CredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null>;
-  save(credential: Credential, timeoutRacer: TimeoutRacer): Promise<void>;
+  hint(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
+      Promise<OYCredential|null>;
+  retrieve(options: OYCredentialRequestOptions, timeoutRacer: TimeoutRacer):
+      Promise<OYCredential|null>;
+  save(credential: OYCredential, timeoutRacer: TimeoutRacer): Promise<void>;
   disableAutoSignIn(timeoutRacer: TimeoutRacer): Promise<void>;
-  proxyLogin(credential: Credential, timeoutRacer: TimeoutRacer):
-      Promise<ProxyLoginResponse>;
+  proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
+      Promise<OYProxyLoginResponse>;
   cancelLastOperation(timeoutRacer: TimeoutRacer): Promise<void>;
 }
 
@@ -240,19 +240,20 @@ async function createOpenYoloApi(
  * TODO: Implement.
  */
 class OpenYoloBrowserApiImpl implements OpenYoloWithTimeoutApi {
-  async retrieve(options: CredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null> {
+  async retrieve(
+      options: OYCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OYCredential|null> {
     return Promise.reject('not implemented');
   }
 
   async hintsAvailable(
-      options: CredentialRequestOptions,
+      options: OYCredentialRequestOptions,
       timeoutRacer: TimeoutRacer): Promise<boolean> {
     return Promise.reject('not implemented');
   }
 
-  async hint(options: CredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null> {
+  async hint(options: OYCredentialRequestOptions, timeoutRacer: TimeoutRacer):
+      Promise<OYCredential|null> {
     return Promise.reject('not implemented');
   }
 
@@ -260,13 +261,13 @@ class OpenYoloBrowserApiImpl implements OpenYoloWithTimeoutApi {
     return Promise.reject('not implemented');
   }
 
-  async save(credential: Credential, timeoutRacer: TimeoutRacer):
+  async save(credential: OYCredential, timeoutRacer: TimeoutRacer):
       Promise<void> {
     return Promise.reject('not implemented');
   }
 
-  async proxyLogin(credential: Credential, timeoutRacer: TimeoutRacer):
-      Promise<ProxyLoginResponse> {
+  async proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
+      Promise<OYProxyLoginResponse> {
     return Promise.reject('not implemented');
   }
 
@@ -287,7 +288,7 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
       private channel: SecureChannel) {}
 
   async hintsAvailable(
-      options: CredentialHintOptions,
+      options: OYCredentialHintOptions,
       timeoutRacer: TimeoutRacer): Promise<boolean> {
     this.checkNotDisposed();
     const request = new HintAvailableRequest(this.frameManager, this.channel);
@@ -299,28 +300,29 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
     }
   }
 
-  async hint(options: CredentialHintOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null> {
+  async hint(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
+      Promise<OYCredential|null> {
     this.checkNotDisposed();
     const request = new HintRequest(this.frameManager, this.channel);
     return await request.dispatch(options, timeoutRacer);
   }
 
-  async retrieve(options: CredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<Credential|null> {
+  async retrieve(
+      options: OYCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OYCredential|null> {
     this.checkNotDisposed();
     const request = new CredentialRequest(this.frameManager, this.channel);
     return await request.dispatch(options, timeoutRacer);
   }
 
-  async save(credential: Credential, timeoutRacer: TimeoutRacer) {
+  async save(credential: OYCredential, timeoutRacer: TimeoutRacer) {
     this.checkNotDisposed();
     const request = new CredentialSave(this.frameManager, this.channel);
     return await request.dispatch(credential, timeoutRacer);
   }
 
-  async proxyLogin(credential: Credential, timeoutRacer: TimeoutRacer):
-      Promise<ProxyLoginResponse> {
+  async proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
+      Promise<OYProxyLoginResponse> {
     this.checkNotDisposed();
     const request = new ProxyLogin(this.frameManager, this.channel);
     return await request.dispatch(credential, timeoutRacer);
@@ -460,21 +462,22 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
                                          defaultTimeoutMs);
   }
 
-  async hintsAvailable(options: CredentialHintOptions): Promise<boolean> {
+  async hintsAvailable(options: OYCredentialHintOptions): Promise<boolean> {
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.hintsAvailable);
     const impl = await this.init(timeoutRacer);
     return await impl.hintsAvailable(options, timeoutRacer);
   }
 
-  async hint(options: CredentialHintOptions): Promise<Credential|null> {
+  async hint(options: OYCredentialHintOptions): Promise<OYCredential|null> {
     const preloadRequest = {type: PreloadRequestType.hint, options};
     const timeoutRacer = this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.hint);
     const impl = await this.init(timeoutRacer, preloadRequest);
     return await impl.hint(options, timeoutRacer);
   }
 
-  async retrieve(options: CredentialRequestOptions): Promise<Credential|null> {
+  async retrieve(options: OYCredentialRequestOptions):
+      Promise<OYCredential|null> {
     const preloadRequest = {type: PreloadRequestType.retrieve, options};
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.retrieve);
@@ -482,7 +485,7 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     return impl.retrieve(options, timeoutRacer);
   }
 
-  async save(credential: Credential): Promise<void> {
+  async save(credential: OYCredential): Promise<void> {
     const timeoutRacer = this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.save);
     const impl = await this.init(timeoutRacer);
     return impl.save(credential, timeoutRacer);
@@ -495,7 +498,7 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     return impl.disableAutoSignIn(timeoutRacer);
   }
 
-  async proxyLogin(credential: Credential): Promise<ProxyLoginResponse> {
+  async proxyLogin(credential: OYCredential): Promise<OYProxyLoginResponse> {
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.proxyLogin);
     const impl = await this.init(timeoutRacer);

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -15,9 +15,9 @@
  */
 
 import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
-import {RENDER_MODES, RenderMode} from '../protocol/data';
+import {RenderMode} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
-import {PRELOAD_REQUEST, PreloadRequest} from '../protocol/preload_request';
+import {PreloadRequest, PreloadRequestType} from '../protocol/preload_request';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, sha256, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
 
@@ -34,7 +34,7 @@ import {WrapBrowserRequest} from './wrap_browser_request';
 
 // re-export all the data types
 export * from '../protocol/data';
-export {OpenYoloError, ERROR_TYPES} from '../protocol/errors';
+export {OpenYoloError, InternalErrorCode} from '../protocol/errors';
 
 const MOBILE_USER_AGENT_REGEX = /android|iphone|ipod|iemobile/i;
 
@@ -165,18 +165,18 @@ const DEFAULT_TIMEOUTS: {[key in OpenYoloApiMethods]: number} = {
  * Sanitzes the input for renderMode, selecting the default one if invalid.
  */
 function verifyOrDetectRenderMode(renderMode: RenderMode|null): RenderMode {
-  if (renderMode && renderMode in RENDER_MODES) {
+  if (renderMode && renderMode in RenderMode) {
     return renderMode;
   }
   const isNested = window.parent !== window;
   if (isNested) {
-    return RENDER_MODES.fullScreen;
+    return RenderMode.fullScreen;
   }
   const isMobile = navigator.userAgent.match(MOBILE_USER_AGENT_REGEX);
   if (isMobile) {
-    return RENDER_MODES.bottomSheet;
+    return RenderMode.bottomSheet;
   } else {
-    return RENDER_MODES.navPopout;
+    return RenderMode.navPopout;
   }
 }
 
@@ -468,14 +468,14 @@ class InitializeOnDemandApi implements OnDemandOpenYoloApi {
   }
 
   async hint(options: CredentialHintOptions): Promise<Credential|null> {
-    const preloadRequest = {type: PRELOAD_REQUEST.hint, options};
+    const preloadRequest = {type: PreloadRequestType.hint, options};
     const timeoutRacer = this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.hint);
     const impl = await this.init(timeoutRacer, preloadRequest);
     return await impl.hint(options, timeoutRacer);
   }
 
   async retrieve(options: CredentialRequestOptions): Promise<Credential|null> {
-    const preloadRequest = {type: PRELOAD_REQUEST.retrieve, options};
+    const preloadRequest = {type: PreloadRequestType.retrieve, options};
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.retrieve);
     const impl = await this.init(timeoutRacer, preloadRequest);

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -79,7 +79,8 @@ describe('OpenYolo API', () => {
 
         it('resets the API if initialization fails', (done) => {
           const expectedError = new Error('ERROR!');
-          spyOn(DisableAutoSignIn.prototype, 'dispatch');
+          spyOn(DisableAutoSignIn.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           (SecureChannel.clientConnectNoTimeout as jasmine.Spy)
               .and.returnValue(Promise.reject(expectedError));
           openyolo.disableAutoSignIn().then(
@@ -245,7 +246,8 @@ describe('OpenYolo API', () => {
 
       describe('disableAutoSignIn', () => {
         it('never times out', async function(done) {
-          spyOn(DisableAutoSignIn.prototype, 'dispatch');
+          spyOn(DisableAutoSignIn.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.disableAutoSignIn().then(
               () => {
                 done.fail('Should never resolve!');
@@ -262,7 +264,8 @@ describe('OpenYolo API', () => {
         const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
-          spyOn(HintAvailableRequest.prototype, 'dispatch');
+          spyOn(HintAvailableRequest.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.hintsAvailable(options).then(
               () => {
                 done.fail('Should never resolve!');
@@ -279,7 +282,8 @@ describe('OpenYolo API', () => {
         const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
-          spyOn(HintRequest.prototype, 'dispatch');
+          spyOn(HintRequest.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.hint(options).then(
               () => {
                 done.fail('Should never resolve!');
@@ -296,7 +300,8 @@ describe('OpenYolo API', () => {
         const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
-          spyOn(CredentialRequest.prototype, 'dispatch');
+          spyOn(CredentialRequest.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.retrieve(options).then(
               () => {
                 done.fail('Should never resolve!');
@@ -311,7 +316,8 @@ describe('OpenYolo API', () => {
 
       describe('save', () => {
         it('never times out', async function(done) {
-          spyOn(CredentialSave.prototype, 'dispatch');
+          spyOn(CredentialSave.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.save(credential)
               .then(
                   () => {
@@ -326,8 +332,9 @@ describe('OpenYolo API', () => {
       });
 
       describe('proxyLogin', () => {
-        it('nefver times out', async function(done) {
-          spyOn(ProxyLogin.prototype, 'dispatch');
+        it('never times out', async function(done) {
+          spyOn(ProxyLogin.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.proxyLogin(credential)
               .then(
                   () => {
@@ -343,7 +350,8 @@ describe('OpenYolo API', () => {
 
       describe('cancelLastOperation', () => {
         it('never times out', async function(done) {
-          spyOn(CancelLastOperationRequest.prototype, 'dispatch');
+          spyOn(CancelLastOperationRequest.prototype, 'dispatch')
+              .and.returnValue(new Promise(() => {}));
           openyolo.cancelLastOperation().then(
               () => {
                 done.fail('Should never resolve!');

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -15,7 +15,7 @@
  */
 
 import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
 import {SecureChannel} from '../protocol/secure_channel';
 
 import {openyolo} from './api';
@@ -377,7 +377,8 @@ describe('OpenYolo API', () => {
                 done.fail('Should not resolve!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 done();
               });
@@ -393,7 +394,8 @@ describe('OpenYolo API', () => {
                    done.fail('Should not resolve!');
                  },
                  (error) => {
-                   expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                   expect(OpenYoloError.errorIs(
+                              error, InternalErrorCode.requestTimeout))
                        .toBe(true);
                    done();
                  });
@@ -410,7 +412,8 @@ describe('OpenYolo API', () => {
                 done.fail('Should not resolve!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 done();
               });
@@ -425,7 +428,8 @@ describe('OpenYolo API', () => {
                 done.fail('Should not resolve!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 done();
               });
@@ -442,7 +446,8 @@ describe('OpenYolo API', () => {
                 done.fail('Should not resolve!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 done();
               });
@@ -459,7 +464,8 @@ describe('OpenYolo API', () => {
                 done.fail('Should not resolve!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 done();
               });
@@ -475,7 +481,8 @@ describe('OpenYolo API', () => {
                     done.fail('Should not resolve!');
                   },
                   (error) => {
-                    expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                    expect(OpenYoloError.errorIs(
+                               error, InternalErrorCode.requestTimeout))
                         .toBe(true);
                     done();
                   });
@@ -491,7 +498,8 @@ describe('OpenYolo API', () => {
                     done.fail('Should not resolve!');
                   },
                   (error) => {
-                    expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                    expect(OpenYoloError.errorIs(
+                               error, InternalErrorCode.requestTimeout))
                         .toBe(true);
                     done();
                   });

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
+import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
 import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
 import {SecureChannel} from '../protocol/secure_channel';
 
@@ -29,7 +29,7 @@ import {ProxyLogin} from './proxy_login';
 import {WrapBrowserRequest} from './wrap_browser_request';
 
 describe('OpenYolo API', () => {
-  const credential: Credential = {id: 'test', authMethod: 'test'};
+  const credential: OYCredential = {id: 'test', authMethod: 'test'};
   const expectedError = new Error('ERROR!');
   const secureChannelSpy =
       jasmine.createSpyObj('SecureChannel', ['send', 'dispose']);
@@ -97,7 +97,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hintsAvailable', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('works', async function(done) {
           spyOn(HintAvailableRequest.prototype, 'dispatch')
@@ -130,7 +130,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hint', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('works', async function(done) {
           spyOn(HintRequest.prototype, 'dispatch')
@@ -156,7 +156,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('retrieve', () => {
-        const options: CredentialRequestOptions = {supportedAuthMethods: []};
+        const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
 
         it('works', async function(done) {
           spyOn(CredentialRequest.prototype, 'dispatch')
@@ -208,7 +208,7 @@ describe('OpenYolo API', () => {
       describe('proxyLogin', () => {
         it('works', async function(done) {
           const expectedResponse:
-              ProxyLoginResponse = {statusCode: 200, responseText: 'test'};
+              OYProxyLoginResponse = {statusCode: 200, responseText: 'test'};
           spyOn(ProxyLogin.prototype, 'dispatch')
               .and.returnValue(Promise.resolve(expectedResponse));
           openyolo.proxyLogin(credential).then((result) => {
@@ -259,7 +259,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hintsAvailable', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
           spyOn(HintAvailableRequest.prototype, 'dispatch');
@@ -276,7 +276,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hint', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
           spyOn(HintRequest.prototype, 'dispatch');
@@ -293,7 +293,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('retrieve', () => {
-        const options: CredentialRequestOptions = {supportedAuthMethods: []};
+        const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
 
         it('never times out', async function(done) {
           spyOn(CredentialRequest.prototype, 'dispatch');
@@ -404,7 +404,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hintsAvailable', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('times out', async function(done) {
           openyolo.hintsAvailable(options).then(
@@ -438,7 +438,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('hint', () => {
-        const options: CredentialHintOptions = {supportedAuthMethods: []};
+        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
 
         it('times out', async function(done) {
           openyolo.hint(options).then(
@@ -456,7 +456,7 @@ describe('OpenYolo API', () => {
       });
 
       describe('retrieve', () => {
-        const options: CredentialRequestOptions = {supportedAuthMethods: []};
+        const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
 
         it('times out', async function(done) {
           openyolo.retrieve(options).then(

--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {OpenYoloError} from '../protocol/errors';
-import {errorMessage, noneAvailableMessage, RPC_MESSAGE_TYPES, showProviderMessage} from '../protocol/rpc_messages';
+import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
+import {errorMessage, noneAvailableMessage, RpcMessageType, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {startTimeoutRacer} from '../protocol/utils';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -60,13 +60,13 @@ describe('BaseRequest', () => {
 
   describe('registerHandler', () => {
     beforeEach(() => {
-      request.registerHandler(RPC_MESSAGE_TYPES.none, handlerSpy);
+      request.registerHandler(RpcMessageType.none, handlerSpy);
     });
 
     it('should unlisten when disposed', () => {
       // Listener for a different message type.
       request.registerHandler(
-          RPC_MESSAGE_TYPES.credential, jasmine.createSpy('messageSpy'));
+          RpcMessageType.credential, jasmine.createSpy('messageSpy'));
       request.dispose();
       expect(unlistenSpy).toHaveBeenCalledTimes(2);
     });
@@ -97,7 +97,8 @@ describe('BaseRequest', () => {
                 done.fail('Should not be a success!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(error, 'requestTimeout'))
+                expect(OpenYoloError.errorIs(
+                           error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 expect(frame.hide).toHaveBeenCalled();
                 done();

--- a/ts/api/cancel_last_operation_request.ts
+++ b/ts/api/cancel_last_operation_request.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {cancelLastOperationMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {cancelLastOperationMessage, RpcMessageType} from '../protocol/rpc_messages';
 import {BaseRequest} from './base_request';
 
 export class CancelLastOperationRequest extends BaseRequest<void, void> {
   dispatchInternal() {
     this.registerHandler(
-        RPC_MESSAGE_TYPES.cancelLastOperationResult, () => this.handleResult());
+        RpcMessageType.cancelLastOperationResult, () => this.handleResult());
     // send the request
     this.channel.send(cancelLastOperationMessage(this.id));
   }

--- a/ts/api/credential_request.ts
+++ b/ts/api/credential_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialRequestOptions} from '../protocol/data';
+import {OYCredential, OYCredentialRequestOptions} from '../protocol/data';
 import {retrieveMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -24,16 +24,16 @@ import {BaseRequest} from './base_request';
  * the user selects a credential, if any is available.
  */
 export class CredentialRequest extends
-    BaseRequest<Credential|null, CredentialRequestOptions|undefined> {
+    BaseRequest<OYCredential|null, OYCredentialRequestOptions|undefined> {
   /**
    * Starts the Credential Request flow.
    */
-  dispatchInternal(options: CredentialRequestOptions) {
+  dispatchInternal(options: OYCredentialRequestOptions) {
     // the final outcome will either be a credential, or a notification that
     // none are available / none was selected by the user.
     this.registerHandler(
         RpcMessageType.credential,
-        (credential: Credential) => this.handleResult(credential));
+        (credential: OYCredential) => this.handleResult(credential));
     this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     // send the request
@@ -43,7 +43,7 @@ export class CredentialRequest extends
   /**
    * Handles the initial response from a credential request.
    */
-  private handleResult(credential: Credential|null): void {
+  private handleResult(credential: OYCredential|null): void {
     this.resolve(credential);
     this.dispose();
   }

--- a/ts/api/credential_request.ts
+++ b/ts/api/credential_request.ts
@@ -15,7 +15,7 @@
  */
 
 import {Credential, CredentialRequestOptions} from '../protocol/data';
-import {retrieveMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {retrieveMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -32,9 +32,9 @@ export class CredentialRequest extends
     // the final outcome will either be a credential, or a notification that
     // none are available / none was selected by the user.
     this.registerHandler(
-        RPC_MESSAGE_TYPES.credential,
+        RpcMessageType.credential,
         (credential: Credential) => this.handleResult(credential));
-    this.registerHandler(RPC_MESSAGE_TYPES.none, () => this.handleResult(null));
+    this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     // send the request
     this.channel.send(retrieveMessage(this.id, options));

--- a/ts/api/credential_request_test.ts
+++ b/ts/api/credential_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, Credential, CredentialRequestOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredential, OYCredentialRequestOptions} from '../protocol/data';
 import {credentialResultMessage, noneAvailableMessage, retrieveMessage, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -29,7 +29,7 @@ describe('CredentialRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: ProviderFrameElement;
-  const options: CredentialRequestOptions = {supportedAuthMethods: []};
+  const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
 
   beforeEach(() => {
     connection = new FakeProviderConnection();
@@ -48,7 +48,7 @@ describe('CredentialRequest', () => {
   describe('dispatch', () => {
     it('should send a RPC message through the channel', () => {
       spyOn(clientChannel, 'send').and.callThrough();
-      let options: CredentialRequestOptions = {
+      let options: OYCredentialRequestOptions = {
         supportedAuthMethods: ['openyolo://id-and-password']
       };
       request.dispatch(options);
@@ -78,7 +78,7 @@ describe('CredentialRequest', () => {
     });
 
     it('should resolve with credential on success', async function(done) {
-      let credential: Credential = {
+      let credential: OYCredential = {
         id: 'alice@gmail.com',
         authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
         displayName: 'Google'

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -16,13 +16,13 @@
 
 import {Credential} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
-import {RPC_MESSAGE_TYPES, saveMessage} from '../protocol/rpc_messages';
+import {RpcMessageType, saveMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
 export class CredentialSave extends BaseRequest<void, Credential> {
   dispatchInternal(credential: Credential) {
-    this.registerHandler(RPC_MESSAGE_TYPES.saveResult, (saved: boolean) => {
+    this.registerHandler(RpcMessageType.saveResult, (saved: boolean) => {
       if (saved) {
         this.resolve();
       } else {

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {Credential} from '../protocol/data';
+import {OYCredential} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import {RpcMessageType, saveMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
-export class CredentialSave extends BaseRequest<void, Credential> {
-  dispatchInternal(credential: Credential) {
+export class CredentialSave extends BaseRequest<void, OYCredential> {
+  dispatchInternal(credential: OYCredential) {
     this.registerHandler(RpcMessageType.saveResult, (saved: boolean) => {
       if (saved) {
         this.resolve();

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -16,7 +16,7 @@
 
 import {Credential} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {ERROR_TYPES, OpenYoloError} from '../protocol/errors';
+import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
 import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -77,7 +77,8 @@ describe('CredentialSave', () => {
       await promise;
       done.fail('promise should be rejected');
     } catch (err) {
-      expect(OpenYoloError.errorIs(err, ERROR_TYPES.canceled)).toBeTruthy();
+      expect(OpenYoloError.errorIs(err, InternalErrorCode.userCanceled))
+          .toBeTruthy();
       expect(request.dispose).toHaveBeenCalled();
       done();
     }
@@ -92,7 +93,7 @@ describe('CredentialSave', () => {
       await promise;
       done.fail('Promise should be rejected');
     } catch (err) {
-      expect(OpenYoloError.errorIs(err, ERROR_TYPES.requestFailed))
+      expect(OpenYoloError.errorIs(err, InternalErrorCode.requestFailed))
           .toBeTruthy();
       expect(request.dispose).toHaveBeenCalled();
       done();

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential} from '../protocol/data';
+import {OYCredential} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
 import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
 import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_messages';
@@ -29,7 +29,7 @@ describe('CredentialSave', () => {
   let providerChannel: SecureChannel;
   let request: CredentialSave;
   let frame: any;
-  let credential: Credential = {
+  let credential: OYCredential = {
     id: 'user@example.com',
     authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
     displayName: 'User',

--- a/ts/api/disable_auto_sign_in.ts
+++ b/ts/api/disable_auto_sign_in.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {disableAutoSignInMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {disableAutoSignInMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -26,7 +26,7 @@ export class DisableAutoSignIn extends BaseRequest<undefined, undefined> {
    * Sends the RPC to the IFrame and waits for the result.
    */
   dispatchInternal() {
-    this.registerHandler(RPC_MESSAGE_TYPES.disableAutoSignInResult, () => {
+    this.registerHandler(RpcMessageType.disableAutoSignInResult, () => {
       this.resolve();
       this.dispose();
     });

--- a/ts/api/hint_available_request.ts
+++ b/ts/api/hint_available_request.ts
@@ -15,7 +15,7 @@
  */
 
 import {CredentialHintOptions} from '../protocol/data';
-import {hintAvailableMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {hintAvailableMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -30,7 +30,7 @@ export class HintAvailableRequest extends
    */
   dispatchInternal(options: CredentialHintOptions) {
     this.registerHandler(
-        RPC_MESSAGE_TYPES.hintAvailableResult, (available: boolean) => {
+        RpcMessageType.hintAvailableResult, (available: boolean) => {
           this.resolve(available);
           this.dispose();
         });

--- a/ts/api/hint_available_request.ts
+++ b/ts/api/hint_available_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CredentialHintOptions} from '../protocol/data';
+import {OYCredentialHintOptions} from '../protocol/data';
 import {hintAvailableMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -24,11 +24,11 @@ import {BaseRequest} from './base_request';
  * any user interaction, and if fails, just return as if there was no hints.
  */
 export class HintAvailableRequest extends
-    BaseRequest<boolean, CredentialHintOptions> {
+    BaseRequest<boolean, OYCredentialHintOptions> {
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatchInternal(options: CredentialHintOptions) {
+  dispatchInternal(options: OYCredentialHintOptions) {
     this.registerHandler(
         RpcMessageType.hintAvailableResult, (available: boolean) => {
           this.resolve(available);

--- a/ts/api/hint_available_request_test.ts
+++ b/ts/api/hint_available_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, CredentialHintOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredentialHintOptions} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import {errorMessage, hintAvailableMessage, hintAvailableResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
@@ -28,7 +28,7 @@ describe('HintAvailableRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let passwordOnlyOptions: CredentialHintOptions = {
+  let passwordOnlyOptions: OYCredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
 

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -15,7 +15,7 @@
  */
 
 import {Credential, CredentialHintOptions} from '../protocol/data';
-import {hintMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {hintMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -30,9 +30,9 @@ export class HintRequest extends
    */
   dispatchInternal(options: CredentialHintOptions) {
     this.registerHandler(
-        RPC_MESSAGE_TYPES.credential,
+        RpcMessageType.credential,
         (credential: Credential) => this.handleResult(credential));
-    this.registerHandler(RPC_MESSAGE_TYPES.none, () => this.handleResult(null));
+    this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     this.debugLog(`Sending hint request`);
     this.channel.send(hintMessage(this.id, options));

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialHintOptions} from '../protocol/data';
+import {OYCredential, OYCredentialHintOptions} from '../protocol/data';
 import {hintMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -24,14 +24,14 @@ import {BaseRequest} from './base_request';
  * the user selects a hint, if any is available.
  */
 export class HintRequest extends
-    BaseRequest<Credential|null, CredentialHintOptions|undefined> {
+    BaseRequest<OYCredential|null, OYCredentialHintOptions|undefined> {
   /**
    * Starts the Hint Request flow.
    */
-  dispatchInternal(options: CredentialHintOptions) {
+  dispatchInternal(options: OYCredentialHintOptions) {
     this.registerHandler(
         RpcMessageType.credential,
-        (credential: Credential) => this.handleResult(credential));
+        (credential: OYCredential) => this.handleResult(credential));
     this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     this.debugLog(`Sending hint request`);
@@ -41,7 +41,7 @@ export class HintRequest extends
   /**
    * Handles the initial response from a hint request.
    */
-  private handleResult(credential: Credential|null): void {
+  private handleResult(credential: OYCredential|null): void {
     this.debugLog(`Hint request complete`);
     this.resolve(credential);
     this.dispose();

--- a/ts/api/hint_request_test.ts
+++ b/ts/api/hint_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, Credential, CredentialHintOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredential, OYCredentialHintOptions} from '../protocol/data';
 import {credentialResultMessage, hintMessage, noneAvailableMessage, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -27,8 +27,8 @@ describe('HintRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let hint: Credential;
-  let passwordOnlyOptions: CredentialHintOptions = {
+  let hint: OYCredential;
+  let passwordOnlyOptions: OYCredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
 
@@ -54,7 +54,7 @@ describe('HintRequest', () => {
   describe('dispatch', () => {
     it('should send a RPC message to the frame', () => {
       spyOn(clientChannel, 'send').and.callThrough();
-      let options: CredentialHintOptions = {
+      let options: OYCredentialHintOptions = {
         supportedAuthMethods: ['openyolo://id-and-password']
       };
       request.dispatch(options);

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, Credential as OpenYoloCredential, CredentialHintOptions, CredentialRequestOptions as OpenYoloCredentialRequestOptions, ProxyLoginResponse} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredential as OpenYoloCredential, OYCredentialHintOptions, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 
 import {OpenYoloApi} from './api';
@@ -151,7 +151,9 @@ export class NavigatorCredentials implements OpenYoloApi {
       Promise<OpenYoloCredential> {
     let convertedOptions = convertRequestOptions(options);
     return this.cmApi.get(convertedOptions).then((cred) => {
-      if (!cred) return;
+      if (!cred) {
+        throw OpenYoloError.canceled();
+      }
       this.credentialsMap.insert(cred);
       return convertCredentialToOpenYolo(
           cred as FederatedCredential | PasswordCredential);
@@ -166,7 +168,7 @@ export class NavigatorCredentials implements OpenYoloApi {
     });
   }
 
-  hint(options?: CredentialHintOptions): Promise<OpenYoloCredential> {
+  hint(options?: OYCredentialHintOptions): Promise<OpenYoloCredential> {
     // Reject with a canceled error as no hints can be retrieved.
     return Promise.reject(OpenYoloError.canceled());
   }
@@ -179,7 +181,7 @@ export class NavigatorCredentials implements OpenYoloApi {
     return Promise.reject(OpenYoloError.apiDisabled());
   }
 
-  proxyLogin(credential: OpenYoloCredential): Promise<ProxyLoginResponse> {
+  proxyLogin(credential: OpenYoloCredential): Promise<OYProxyLoginResponse> {
     // TODO(tch): Fetch the URL from configuration.
     let url = `${window.location.protocol}//${window.location.host}/signin`;
     const cred = this.credentialsMap.retrieve(
@@ -188,7 +190,7 @@ export class NavigatorCredentials implements OpenYoloApi {
       return Promise.reject(new Error('Invalid credential!'));
     }
 
-    return new Promise<ProxyLoginResponse>((resolve, reject) => {
+    return new Promise<OYProxyLoginResponse>((resolve, reject) => {
       fetch(url, {method: 'POST', credentials: cred}).then(resp => {
         if (resp.status !== 200) {
           reject(

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential as OpenYoloCredential, CredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
+import {OYCredential as OpenYoloCredential, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
 
 import {NavigatorCredentials} from './navigator_credentials';

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -16,6 +16,7 @@
 
 import {OYCredential as OpenYoloCredential, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
+import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
 
 import {NavigatorCredentials} from './navigator_credentials';
 
@@ -94,12 +95,17 @@ describe('NavigatorCredentials', () => {
       });
     });
 
-    it('returns nothing', done => {
+    it('rejects when no credential', done => {
       spyOn(cmApi, 'get').and.returnValue(Promise.resolve());
-      navigatorCredentials.retrieve().then(credential => {
-        expect(credential).toBeUndefined();
-        done();
-      });
+      navigatorCredentials.retrieve().then(
+          credential => {
+            done.fail('Should not resolve!');
+          },
+          (error) => {
+            expect(
+                OpenYoloError.errorIs(error, InternalErrorCode.userCanceled));
+            done();
+          });
     });
 
     it('fails', done => {

--- a/ts/api/provider_frame_elem.ts
+++ b/ts/api/provider_frame_elem.ts
@@ -18,7 +18,7 @@ import {WindowLike} from '../protocol/comms';
 import {PreloadRequest} from '../protocol/preload_request';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
-import {RENDER_MODES, RenderMode} from './api';
+import {RenderMode} from './api';
 
 export const HIDDEN_FRAME_CLASS = 'openyolo-hidden';
 export const VISIBLE_FRAME_CLASS = 'openyolo-visible';
@@ -116,7 +116,7 @@ export class ProviderFrameElement {
     this.frameElem.classList.add(VISIBLE_FRAME_CLASS);
     this.frameElem.classList.add(this.renderMode);
     if ((options.height || options.width) &&
-        this.renderMode !== RENDER_MODES.fullScreen) {
+        this.renderMode !== RenderMode.fullScreen) {
       if (options.height) this.frameElem.style.height = `${options.height}px`;
       if (options.width) this.frameElem.style.width = `${options.width}px`;
     }

--- a/ts/api/proxy_login.ts
+++ b/ts/api/proxy_login.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, ProxyLoginResponse} from '../protocol/data';
+import {OYCredential, OYProxyLoginResponse} from '../protocol/data';
 import {proxyLoginMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -22,13 +22,14 @@ import {BaseRequest} from './base_request';
 /**
  * Handles the proxy login.
  */
-export class ProxyLogin extends BaseRequest<ProxyLoginResponse, Credential> {
+export class ProxyLogin extends
+    BaseRequest<OYProxyLoginResponse, OYCredential> {
   /**
    * Starts the Proxy Login flow.
    */
-  dispatchInternal(credential: Credential) {
+  dispatchInternal(credential: OYCredential) {
     this.registerHandler(
-        RpcMessageType.proxyResult, (response: ProxyLoginResponse) => {
+        RpcMessageType.proxyResult, (response: OYProxyLoginResponse) => {
           this.resolve(response);
           this.dispose();
         });

--- a/ts/api/proxy_login.ts
+++ b/ts/api/proxy_login.ts
@@ -15,7 +15,7 @@
  */
 
 import {Credential, ProxyLoginResponse} from '../protocol/data';
-import {proxyLoginMessage, RPC_MESSAGE_TYPES} from '../protocol/rpc_messages';
+import {proxyLoginMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -28,7 +28,7 @@ export class ProxyLogin extends BaseRequest<ProxyLoginResponse, Credential> {
    */
   dispatchInternal(credential: Credential) {
     this.registerHandler(
-        RPC_MESSAGE_TYPES.proxyResult, (response: ProxyLoginResponse) => {
+        RpcMessageType.proxyResult, (response: ProxyLoginResponse) => {
           this.resolve(response);
           this.dispose();
         });

--- a/ts/api/proxy_login_test.ts
+++ b/ts/api/proxy_login_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, Credential} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredential} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import {errorMessage, proxyLoginMessage, proxyLoginResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
@@ -28,7 +28,7 @@ describe('ProxyLogin', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let credential: Credential = {
+  let credential: OYCredential = {
     id: 'user@example.com',
     displayName: 'User',
     password: 'password',

--- a/ts/api/verify.ts
+++ b/ts/api/verify.ts
@@ -15,7 +15,7 @@
  */
 
 import {createMessageListener, FilteringEventListener, sendMessage, WindowLike} from '../protocol/comms';
-import {POST_MESSAGE_TYPES, verifyAckMessage} from '../protocol/post_messages';
+import {PostMessageType, verifyAckMessage} from '../protocol/post_messages';
 
 let listener: FilteringEventListener;
 
@@ -24,7 +24,7 @@ export function respondToHandshake(window: WindowLike): void {
     window.removeEventListener('message', listener);
   }
   listener =
-      createMessageListener(POST_MESSAGE_TYPES.verifyPing, (data, type, ev) => {
+      createMessageListener(PostMessageType.verifyPing, (data, type, ev) => {
         console.debug(`responding to ping from ${ev.origin}`);
         sendMessage(ev.source, verifyAckMessage(data), ev.origin);
       });

--- a/ts/api/wrap_browser_request.ts
+++ b/ts/api/wrap_browser_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {RPC_MESSAGE_TYPES, wrapBrowserMessage} from '../protocol/rpc_messages';
+import {RpcMessageType, wrapBrowserMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
@@ -28,7 +28,7 @@ export class WrapBrowserRequest extends BaseRequest<boolean, undefined> {
    */
   dispatchInternal() {
     this.registerHandler(
-        RPC_MESSAGE_TYPES.wrapBrowserResult, (wrapBrowser: boolean) => {
+        RpcMessageType.wrapBrowserResult, (wrapBrowser: boolean) => {
           this.resolve(wrapBrowser);
           this.dispose();
         });

--- a/ts/protocol/comms.ts
+++ b/ts/protocol/comms.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {isOpenYoloMessageFormat, Message, MESSAGE_DATA_VALIDATORS, MessageDataTypes, MessageType} from './messages';
+import {isOpenYoloMessageFormat, Message, MESSAGE_DATA_VALIDATORS, MessageData, MessageType} from './messages';
 import {PostMessageData, PostMessageType} from './post_messages';
 import {RpcMessageData, RpcMessageType} from './rpc_messages';
 
@@ -55,7 +55,7 @@ export type RpcMessageListener<T extends RpcMessageType> =
     (data: RpcMessageData<T>, type: T, event: MessageEvent) => void;
 
 export type MessageListener<T extends MessageType> =
-    (data: MessageDataTypes[T], type: T, event: MessageEvent) => void;
+    (data: MessageData<T>, type: T, event: MessageEvent) => void;
 
 export type FilteringEventListener = (ev: MessageEvent) => boolean;
 
@@ -87,7 +87,7 @@ export function createMessageListener<T extends MessageType>(
 }
 
 export interface TypedMessageEvent<T extends MessageType> extends MessageEvent {
-  data: MessageDataTypes[T];
+  data: MessageData<T>;
 }
 
 export type MessageEventListener<T extends MessageType> =

--- a/ts/protocol/comms.ts
+++ b/ts/protocol/comms.ts
@@ -15,8 +15,8 @@
  */
 
 import {isOpenYoloMessageFormat, Message, MESSAGE_DATA_VALIDATORS, MessageDataTypes, MessageType} from './messages';
-import {PostMessageDataTypes, PostMessageType} from './post_messages';
-import {RpcMessageDataTypes, RpcMessageType} from './rpc_messages';
+import {PostMessageData, PostMessageType} from './post_messages';
+import {RpcMessageData, RpcMessageType} from './rpc_messages';
 
 /**
  * Interface exposing only the required properties and methods of the Window
@@ -49,10 +49,10 @@ export function isPermittedOrigin(
 }
 
 export type PostMessageListener<T extends PostMessageType> =
-    (data: PostMessageDataTypes[T], type: T, event: MessageEvent) => void;
+    (data: PostMessageData<T>, type: T, event: MessageEvent) => void;
 
 export type RpcMessageListener<T extends RpcMessageType> =
-    (data: RpcMessageDataTypes[T], type: T, event: MessageEvent) => void;
+    (data: RpcMessageData<T>, type: T, event: MessageEvent) => void;
 
 export type MessageListener<T extends MessageType> =
     (data: MessageDataTypes[T], type: T, event: MessageEvent) => void;

--- a/ts/protocol/comms_test.ts
+++ b/ts/protocol/comms_test.ts
@@ -17,7 +17,7 @@
 import {createUntypedMessageEvent} from '../test_utils/messages';
 
 import {createMessageListener, isPermittedOrigin, PostMessageListener, sendMessage} from './comms';
-import {channelReadyMessage, POST_MESSAGE_TYPES} from './post_messages';
+import {channelReadyMessage, PostMessageType} from './post_messages';
 
 describe('comms', () => {
   describe('isPermittedOrigin', () => {
@@ -52,12 +52,12 @@ describe('comms', () => {
   });
 
   describe('createMessageListener', () => {
-    let spy: PostMessageListener<typeof POST_MESSAGE_TYPES.verifyPing>;
+    let spy: PostMessageListener<typeof PostMessageType.verifyPing>;
     let listener: EventListener;
 
     beforeEach(() => {
       spy = jasmine.createSpy('listener');
-      listener = createMessageListener(POST_MESSAGE_TYPES.verifyPing, spy);
+      listener = createMessageListener(PostMessageType.verifyPing, spy);
     });
 
     it('ignores events without content', () => {
@@ -80,16 +80,16 @@ describe('comms', () => {
     it('filters events with invalid data', () => {
       // ping message data must be a string
       let event = createUntypedMessageEvent(
-          {data: {type: POST_MESSAGE_TYPES.verifyPing, data: 0}});
+          {data: {type: PostMessageType.verifyPing, data: 0}});
       listener(event);
       expect(spy).not.toHaveBeenCalled();
     });
 
     it('passes valid messages', () => {
-      let event = {data: {type: POST_MESSAGE_TYPES.verifyPing, data: '123'}};
+      let event = {data: {type: PostMessageType.verifyPing, data: '123'}};
       listener(event as MessageEvent);
       expect(spy).toHaveBeenCalledWith(
-          '123', POST_MESSAGE_TYPES.verifyPing, event);
+          '123', PostMessageType.verifyPing, event);
     });
   });
 });

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -26,7 +26,7 @@ import {PasswordSpecification} from './password_spec';
 /**
  * Represents a credential which may be usable to sign in.
  */
-export interface Credential {
+export interface OYCredential {
   /**
    * The unique identifier for the credential within the scope of the
    * authentication system. This is typically an email address, phone number
@@ -102,7 +102,7 @@ export interface Credential {
 /**
  * Encapsulates the response from the authentication system to a proxy login.
  */
-export interface ProxyLoginResponse {
+export interface OYProxyLoginResponse {
   statusCode: number;
   responseText: string;
 }
@@ -111,7 +111,7 @@ export interface ProxyLoginResponse {
  * The set of parameters passed from the client for a credential retrieval
  * request.
  */
-export interface CredentialRequestOptions {
+export interface OYCredentialRequestOptions {
   /**
    * The supported authentication methods supported by the origin, described
    * as a list of absolute, hierarchical URLs with no path. See
@@ -151,7 +151,7 @@ export interface TokenProvider {
 /**
  * The set of parameters passed from the client for a hint retrieval request.
  */
-export interface CredentialHintOptions {
+export interface OYCredentialHintOptions {
   /**
    * The supported authentication methods supported by the origin, described
    * as a list of absolute, hierarchical URLs with no path. See

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {boxEnum, indexedStrEnum, map2Enum} from './enums';
+import {boxEnum, indexedStrEnum} from './enums';
 import {PasswordSpecification} from './password_spec';
 
 /**
@@ -190,13 +190,11 @@ export interface CredentialHintOptions {
  * - navPopout: The provider is rendered in a pop-up style at the top of the
  *   screen, with a fixed width. The
  */
-export const RENDER_MODES = map2Enum({
-  bottomSheet: 'bottomSheet',
-  navPopout: 'navPopout',
-  fullScreen: 'fullScreen'
-});
-
-export type RenderMode = keyof typeof RENDER_MODES;
+export enum RenderMode {
+  bottomSheet = 'bottomSheet',
+  navPopout = 'navPopout',
+  fullScreen = 'fullScreen'
+}
 
 /**
  * A set of commonly-used federated authentication methods. This list is not

--- a/ts/protocol/enums.ts
+++ b/ts/protocol/enums.ts
@@ -14,29 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * A TypeScript utility for producing a string enumeration, retaining enough
- * string literal type information to be usable for static checking.
- *
- * The function produces an object, where for each string value _s_ provided as
- * an argument, the key s maps to the value s, with string literal type s.
- * For example, `animals = strEnum('cat', 'dog', 'pig')` produces the object
- * `{cat: 'cat', dog: 'dog', 'pig': pig}`, where `typeof animals.cat === 'cat'`.
- */
-export function strEnum<T extends string>(...enumValues: T[]):
-    Readonly<{[K in T]: K}> {
-  let result = enumValues.reduce((res, key) => {
-    res[key] = key;
-    return res;
-  }, Object.create(null));
-  return Object.freeze(result);
-}
-
-export function map2Enum<T extends string>(mapValues: {[K in T]: K}):
-    Readonly<{[K in T]: K}> {
-  return Object.freeze(mapValues);
-}
-
 export type StringKeyedObject = {
   [key: string]: any
 };

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -14,36 +14,28 @@
  * limitations under the License.
  */
 
-import {map2Enum} from './enums';
-
-export const ERROR_TYPES = map2Enum({
-  ackTimeout: 'ackTimeout',
-  canceled: 'canceled',
-  cancelledLastOperation: 'cancelledLastOperation',
-  clientDisposed: 'clientDisposed',
-  handshakeFailed: 'handshakeFailed',
-  invalidCredential: 'invalidCredential',
-  invalidData: 'invalidData',
-  iframeError: 'iframeError',
-  invalidOrigin: 'invalidOrigin',
-  untrustedOrigin: 'untrustedOrigin',
-  requestFailed: 'requestFailed',
-  requestTimeout: 'requestTimeout',
-  illegalState: 'illegalState',
-  illegalConcurrentRequest: 'illegalConcurrentRequest',
-  establishSecureChannelTimeout: 'establishSecureChannelTimeout',
-  unknownRequest: 'unknownRequest',
-  apiDisabled: 'apiDisabled',
-  parentVerifyTimeout: 'parentVerifyTimeout',
-  parentIsNotRoot: 'parentIsNotRoot',
-  providerInitFailed: 'providerInitFailed',
-  unknown: 'unknown'
-});
-
-export type ErrorType = keyof typeof ERROR_TYPES;
+export enum InternalErrorCode {
+  ackTimeout = 'ackTimeout',
+  establishSecureChannelTimeout = 'establishSecureChannelTimeout',
+  parentVerifyTimeout = 'parentVerifyTimeout',
+  illegalStateError = 'illegalStateError',
+  providerInitializationFailed = 'providerInitializationFailed',
+  apiDisabled = 'apiDisabled',
+  untrustedOrigin = 'untrustedOrigin',
+  parentIsNotRoot = 'parentIsNotRoot',
+  userCanceled = 'userCanceled',
+  noCredentialsAvailable = 'noCredentialsAvailable',
+  operationCanceled = 'operationCanceled',
+  clientDisposed = 'clientDisposed',
+  requestFailed = 'requestFailed',
+  requestTimeout = 'requestTimeout',
+  illegalConcurrentRequest = 'illegalConcurrentRequest',
+  unknownRequest = 'unknownRequest',
+  unknown = 'unknown'
+}
 
 export interface OpenYoloErrorData {
-  code: ErrorType;
+  code: InternalErrorCode;
   message: string;
   info?: {[key: string]: string};
 }
@@ -55,126 +47,102 @@ export interface OpenYoloExtendedError extends Error {
 export class OpenYoloError {
   static ackTimeout() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.ackTimeout,
+      code: InternalErrorCode.ackTimeout,
       message: 'Message acknowledgement timed out.'
     });
   }
 
   static canceled() {
     return OpenYoloError.createError(
-        {code: ERROR_TYPES.canceled, message: 'User canceled'});
+        {code: InternalErrorCode.userCanceled, message: 'User canceled'});
   }
 
   static clientCancelled() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.cancelledLastOperation,
+      code: InternalErrorCode.operationCanceled,
       message: 'Operation cancelled'
     });
   }
 
   static clientDisposed() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.clientDisposed,
+      code: InternalErrorCode.clientDisposed,
       message: 'Client is disposed and no longer usable'
     });
   }
 
-  static handshake(reason: string) {
-    return OpenYoloError.createError(
-        {code: ERROR_TYPES.handshakeFailed, message: reason});
-  }
-
-  static invalidCredential() {
-    return OpenYoloError.createError({
-      code: ERROR_TYPES.invalidCredential,
-      message: 'The provided credential is invalid'
-    });
-  }
-
-  static invalidData() {
-    return OpenYoloError.createError({
-      code: ERROR_TYPES.invalidData,
-      message: 'Message contained invalid data'
-    });
-  }
-
-  static iframe(cause: string) {
-    return OpenYoloError.createError(
-        {code: ERROR_TYPES.iframeError, message: `IFrame error: ${cause}`});
-  }
-
   static untrustedOrigin(origin: string) {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.untrustedOrigin,
+      code: InternalErrorCode.untrustedOrigin,
       message: `Untrusted origin: ${origin}`
     });
   }
 
   static requestFailed(message: string) {
     return OpenYoloError.createError(
-        {code: ERROR_TYPES.requestFailed, message});
+        {code: InternalErrorCode.requestFailed, message});
   }
 
   static requestTimeout() {
     return OpenYoloError.createError(
-        {code: ERROR_TYPES.requestTimeout, message: 'Request timed out'});
+        {code: InternalErrorCode.requestTimeout, message: 'Request timed out'});
   }
 
   static illegalStateError(reason: string) {
     return OpenYoloError.createError(
-        {code: ERROR_TYPES.illegalState, message: reason});
+        {code: InternalErrorCode.illegalStateError, message: reason});
   }
 
   static illegalConcurrentRequestError() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.illegalConcurrentRequest,
+      code: InternalErrorCode.illegalConcurrentRequest,
       message: 'Concurrent requests are not permitted'
     });
   }
 
   static establishSecureChannelTimeout() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.establishSecureChannelTimeout,
+      code: InternalErrorCode.establishSecureChannelTimeout,
       message: 'SecureConnection establishment timed out'
     });
   }
 
   static unknownRequest(requestType: string) {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.unknownRequest,
+      code: InternalErrorCode.unknownRequest,
       message: `Unknown request type ${requestType}`
     });
   }
 
   static apiDisabled() {
     return OpenYoloError.createError(
-        {code: ERROR_TYPES.apiDisabled, message: 'API is disabled'});
-  }
-
-  static unknown() {
-    return OpenYoloError.createError(
-        {code: ERROR_TYPES.unknown, message: 'Unknown error'});
+        {code: InternalErrorCode.apiDisabled, message: 'API is disabled'});
   }
 
   static ancestorVerifyTimeout() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.parentVerifyTimeout,
+      code: InternalErrorCode.parentVerifyTimeout,
       message: `Frame ancestor origin verification timed out`
     });
   }
 
   static parentIsNotRoot() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.parentIsNotRoot,
+      code: InternalErrorCode.parentIsNotRoot,
       message: `Parent frame is not a root window`
     });
   }
 
   static providerInitFailed() {
     return OpenYoloError.createError({
-      code: ERROR_TYPES.providerInitFailed,
+      code: InternalErrorCode.providerInitializationFailed,
       message: `Provider failed to initialize`
     });
+  }
+
+  static unknown() {
+    return OpenYoloError.createError(
+        {code: InternalErrorCode.unknown, message: `Unkown error.`});
   }
 
   static createError(errorData: OpenYoloErrorData): OpenYoloExtendedError {
@@ -183,7 +151,7 @@ export class OpenYoloError {
     return err;
   }
 
-  static errorIs<T extends ErrorType>(err: any, code: T) {
+  static errorIs(err: any, code: InternalErrorCode) {
     // force comparability for the purposes of this dynamic check
     if ('data' in err) {
       return err['data']['code'] === code;

--- a/ts/protocol/messages.ts
+++ b/ts/protocol/messages.ts
@@ -14,17 +14,10 @@
  * limitations under the License.
  */
 
-import {POST_MESSAGE_DATA_VALIDATORS, PostMessageDataTypes, PostMessageType} from './post_messages';
-import {RPC_MESSAGE_DATA_VALIDATORS, RpcMessageDataTypes, RpcMessageType} from './rpc_messages';
+import {POST_MESSAGE_DATA_VALIDATORS, PostMessageType} from './post_messages';
+import {RPC_MESSAGE_DATA_VALIDATORS, RpcMessageType} from './rpc_messages';
 
 export type MessageType = PostMessageType | RpcMessageType;
-
-export type MessageDataTypes = PostMessageDataTypes & RpcMessageDataTypes;
-
-export interface Message<T extends MessageType> {
-  type: T;
-  data: MessageDataTypes[T];
-}
 
 export function isOpenYoloMessageFormat(msgData: any) {
   return !!msgData && typeof msgData === 'object' && 'type' in msgData &&

--- a/ts/protocol/messages.ts
+++ b/ts/protocol/messages.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-import {POST_MESSAGE_DATA_VALIDATORS, PostMessageType} from './post_messages';
-import {RPC_MESSAGE_DATA_VALIDATORS, RpcMessageType} from './rpc_messages';
+import {POST_MESSAGE_DATA_VALIDATORS, PostMessageData, PostMessageType} from './post_messages';
+import {RPC_MESSAGE_DATA_VALIDATORS, RpcMessageData, RpcMessageType} from './rpc_messages';
 
 export type MessageType = PostMessageType | RpcMessageType;
+
+export type MessageData<T extends MessageType> =
+    PostMessageData<T&PostMessageType>| RpcMessageData<T&RpcMessageType>;
+
+export interface Message<T extends MessageType> {
+  type: T;
+  data: MessageData<T>;
+}
 
 export function isOpenYoloMessageFormat(msgData: any) {
   return !!msgData && typeof msgData === 'object' && 'type' in msgData &&

--- a/ts/protocol/post_messages.ts
+++ b/ts/protocol/post_messages.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import {map2Enum} from './enums';
 import {OpenYoloErrorData, OpenYoloExtendedError} from './errors';
-import {isNonEmptyString, isValidError} from './validators';
+import {DataValidator, isNonEmptyString, isValidError} from './validators';
 
 /**
  * Top-level message envelope types defined for OpenYOLO:
@@ -31,21 +30,14 @@ import {isNonEmptyString, isValidError} from './validators';
  *     indicate it is ready to accept requests.
  * - channelError: sent when establishing the message channel fails.
  */
-export const POST_MESSAGE_TYPES = map2Enum({
-  ack: 'ack',
-  verifyPing: 'verifyPing',
-  verifyAck: 'verifyAck',
-  readyForConnect: 'readyForConnect',
-  channelConnect: 'channelConnect',
-  channelReady: 'channelReady',
-  channelError: 'channelError'
-});
-
-export type PostMessageType = keyof typeof POST_MESSAGE_TYPES;
-
-export interface PostMessage<T extends PostMessageType> {
-  type: T;
-  data: PostMessageDataType<T>;
+export enum PostMessageType {
+  ack = 'ack',
+  verifyPing = 'verifyPing',
+  verifyAck = 'verifyAck',
+  readyForConnect = 'readyForConnect',
+  channelConnect = 'channelConnect',
+  channelReady = 'channelReady',
+  channelError = 'channelError'
 }
 
 /**
@@ -61,11 +53,16 @@ export type PostMessageDataTypes = {
   'channelError': OpenYoloErrorData
 };
 
-export type PostMessageDataType<K extends PostMessageType> =
-    PostMessageDataTypes[K];
+export type PostMessageData<T extends PostMessageType> =
+    PostMessageDataTypes[T];
+
+export interface PostMessage<T extends PostMessageType> {
+  type: T;
+  data: PostMessageDataTypes[T];
+}
 
 export const POST_MESSAGE_DATA_VALIDATORS:
-    {[K in PostMessageType]: (value: any) => boolean} = {
+    {[K in PostMessageType]: DataValidator} = {
       'ack': isNonEmptyString,
       'verifyPing': isNonEmptyString,
       'verifyAck': isNonEmptyString,
@@ -76,34 +73,34 @@ export const POST_MESSAGE_DATA_VALIDATORS:
     };
 
 export function postMessage<T extends PostMessageType>(
-    type: T, data: PostMessageDataType<T>): PostMessage<T> {
+    type: T, data: PostMessageDataTypes[T]): PostMessage<T> {
   return {type, data};
 }
 
 export function ackMessage(id: string) {
-  return postMessage(POST_MESSAGE_TYPES.ack, id);
+  return postMessage(PostMessageType.ack, id);
 }
 
 export function verifyPingMessage(nonce: string) {
-  return postMessage(POST_MESSAGE_TYPES.verifyPing, nonce);
+  return postMessage(PostMessageType.verifyPing, nonce);
 }
 
 export function verifyAckMessage(nonce: string) {
-  return postMessage(POST_MESSAGE_TYPES.verifyAck, nonce);
+  return postMessage(PostMessageType.verifyAck, nonce);
 }
 
 export function channelReadyMessage(nonce: string) {
-  return postMessage(POST_MESSAGE_TYPES.channelReady, nonce);
+  return postMessage(PostMessageType.channelReady, nonce);
 }
 
 export function channelErrorMessage(error: OpenYoloExtendedError) {
-  return postMessage(POST_MESSAGE_TYPES.channelError, error.data);
+  return postMessage(PostMessageType.channelError, error.data);
 }
 
 export function readyForConnectMessage(nonce: string) {
-  return postMessage(POST_MESSAGE_TYPES.readyForConnect, nonce);
+  return postMessage(PostMessageType.readyForConnect, nonce);
 }
 
 export function channelConnectMessage(nonce: string) {
-  return postMessage(POST_MESSAGE_TYPES.channelConnect, nonce);
+  return postMessage(PostMessageType.channelConnect, nonce);
 }

--- a/ts/protocol/preload_request.ts
+++ b/ts/protocol/preload_request.ts
@@ -28,7 +28,7 @@
  * as part of the initial load of the iframe, to speed up handling of these
  * requests.
  */
-import {CredentialHintOptions, CredentialRequestOptions} from './data';
+import {OYCredentialHintOptions, OYCredentialRequestOptions} from './data';
 
 
 export enum PreloadRequestType {
@@ -38,12 +38,12 @@ export enum PreloadRequestType {
 
 export interface HintPreloadRequest {
   type: PreloadRequestType;
-  options: CredentialHintOptions;
+  options: OYCredentialHintOptions;
 }
 
 export interface RetrievePreloadRequest {
   type: PreloadRequestType;
-  options: CredentialRequestOptions;
+  options: OYCredentialRequestOptions;
 }
 
 export type PreloadRequest = HintPreloadRequest | RetrievePreloadRequest;

--- a/ts/protocol/preload_request.ts
+++ b/ts/protocol/preload_request.ts
@@ -28,18 +28,21 @@
  * as part of the initial load of the iframe, to speed up handling of these
  * requests.
  */
-import {CredentialHintOptions} from './data';
-import {map2Enum} from './enums';
+import {CredentialHintOptions, CredentialRequestOptions} from './data';
 
-export const PRELOAD_REQUEST = map2Enum({hint: 'hint', retrieve: 'retrieve'});
+
+export enum PreloadRequestType {
+  hint = 'hint',
+  retrieve = 'retrieve'
+}
 
 export interface HintPreloadRequest {
-  type: typeof PRELOAD_REQUEST.hint;
+  type: PreloadRequestType;
   options: CredentialHintOptions;
 }
 
 export interface RetrievePreloadRequest {
-  type: typeof PRELOAD_REQUEST.retrieve;
+  type: PreloadRequestType;
   options: CredentialRequestOptions;
 }
 

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -78,27 +78,32 @@ function rpcDataValidator(dataValidator: DataValidator): DataValidator {
   };
 }
 
-export const RPC_MESSAGE_DATA_VALIDATORS:
-    {[K in RpcMessageType]: DataValidator} = {
-      'disableAutoSignIn': rpcDataValidator(isUndefined),
-      'disableAutoSignInResult': rpcDataValidator(isUndefined),
-      'retrieve': rpcDataValidator(isValidRequestOptions),
-      'hintAvailable': rpcDataValidator(isValidHintOptions),
-      'hintAvailableResult': rpcDataValidator(isBoolean),
-      'hint': rpcDataValidator(isValidHintOptions),
-      'save': rpcDataValidator(isValidCredential),
-      'saveResult': rpcDataValidator(isBoolean),
-      'proxy': rpcDataValidator(isValidCredential),
-      'proxyResult': rpcDataValidator(isValidProxyLoginResponse),
-      'wrapBrowser': rpcDataValidator(isUndefined),
-      'wrapBrowserResult': rpcDataValidator(isBoolean),
-      'showProvider': rpcDataValidator(isValidDisplayOptions),
-      'none': rpcDataValidator(isUndefined),
-      'credential': rpcDataValidator(isValidCredential),
-      'error': rpcDataValidator(isValidError),
-      'cancelLastOperation': rpcDataValidator(isUndefined),
-      'cancelLastOperationResult': rpcDataValidator(isUndefined)
-    };
+// It is required to provide such index signature to enforce the type of the map
+// association.
+export type RpcMessageDataValidators = {
+  [K in RpcMessageType]: DataValidator
+} & {[key: string]: DataValidator};
+
+export const RPC_MESSAGE_DATA_VALIDATORS: RpcMessageDataValidators = {
+  'disableAutoSignIn': rpcDataValidator(isUndefined),
+  'disableAutoSignInResult': rpcDataValidator(isUndefined),
+  'retrieve': rpcDataValidator(isValidRequestOptions),
+  'hintAvailable': rpcDataValidator(isValidHintOptions),
+  'hintAvailableResult': rpcDataValidator(isBoolean),
+  'hint': rpcDataValidator(isValidHintOptions),
+  'save': rpcDataValidator(isValidCredential),
+  'saveResult': rpcDataValidator(isBoolean),
+  'proxy': rpcDataValidator(isValidCredential),
+  'proxyResult': rpcDataValidator(isValidProxyLoginResponse),
+  'wrapBrowser': rpcDataValidator(isUndefined),
+  'wrapBrowserResult': rpcDataValidator(isBoolean),
+  'showProvider': rpcDataValidator(isValidDisplayOptions),
+  'none': rpcDataValidator(isUndefined),
+  'credential': rpcDataValidator(isValidCredential),
+  'error': rpcDataValidator(isValidError),
+  'cancelLastOperation': rpcDataValidator(isUndefined),
+  'cancelLastOperationResult': rpcDataValidator(isUndefined)
+};
 
 export interface CredentialResponseData { credential: Credential; }
 

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from './data';
+import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from './data';
 import {OpenYoloErrorData, OpenYoloExtendedError} from './errors';
 import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
@@ -42,19 +42,19 @@ export enum RpcMessageType {
 export type RpcMessageArgumentTypes = {
   'disableAutoSignIn': undefined,
   'disableAutoSignInResult': undefined,
-  'retrieve': CredentialRequestOptions,
-  'hintAvailable': CredentialHintOptions,
+  'retrieve': OYCredentialRequestOptions,
+  'hintAvailable': OYCredentialHintOptions,
   'hintAvailableResult': boolean,
-  'hint': CredentialHintOptions,
-  'save': Credential,
+  'hint': OYCredentialHintOptions,
+  'save': OYCredential,
   'saveResult': boolean,
-  'proxy': Credential,
-  'proxyResult': ProxyLoginResponse,
+  'proxy': OYCredential,
+  'proxyResult': OYProxyLoginResponse,
   'showProvider': DisplayOptions,
   'wrapBrowser': undefined,
   'wrapBrowserResult': boolean,
   'none': undefined,
-  'credential': Credential,
+  'credential': OYCredential,
   'error': OpenYoloErrorData,
   'cancelLastOperation': undefined,
   'cancelLastOperationResult': undefined
@@ -105,7 +105,7 @@ export const RPC_MESSAGE_DATA_VALIDATORS: RpcMessageDataValidators = {
   'cancelLastOperationResult': rpcDataValidator(isUndefined)
 };
 
-export interface CredentialResponseData { credential: Credential; }
+export interface CredentialResponseData { credential: OYCredential; }
 
 export interface ErrorMessageData { error: OpenYoloErrorData; }
 
@@ -131,12 +131,13 @@ export function disableAutoSignInResultMessage(id: string) {
   return rpcMessage(RpcMessageType.disableAutoSignInResult, id, undefined);
 }
 
-export function retrieveMessage(id: string, options: CredentialRequestOptions) {
+export function retrieveMessage(
+    id: string, options: OYCredentialRequestOptions) {
   return rpcMessage(RpcMessageType.retrieve, id, options);
 }
 
 export function hintAvailableMessage(
-    id: string, options: CredentialHintOptions) {
+    id: string, options: OYCredentialHintOptions) {
   return rpcMessage(RpcMessageType.hintAvailable, id, options);
 }
 
@@ -144,16 +145,16 @@ export function hintAvailableResponseMessage(id: string, available: boolean) {
   return rpcMessage(RpcMessageType.hintAvailableResult, id, available);
 }
 
-export function hintMessage(id: string, options: CredentialHintOptions) {
+export function hintMessage(id: string, options: OYCredentialHintOptions) {
   return rpcMessage(RpcMessageType.hint, id, options);
 }
 
-export function proxyLoginMessage(id: string, credential: Credential) {
+export function proxyLoginMessage(id: string, credential: OYCredential) {
   return rpcMessage(RpcMessageType.proxy, id, credential);
 }
 
 export function proxyLoginResponseMessage(
-    id: string, response: ProxyLoginResponse) {
+    id: string, response: OYProxyLoginResponse) {
   return rpcMessage(RpcMessageType.proxyResult, id, response);
 }
 
@@ -170,7 +171,7 @@ export function noneAvailableMessage(id: string) {
   return rpcMessage(RpcMessageType.none, id, undefined);
 }
 
-export function credentialResultMessage(id: string, credential: Credential) {
+export function credentialResultMessage(id: string, credential: OYCredential) {
   return rpcMessage(RpcMessageType.credential, id, credential);
 }
 
@@ -178,7 +179,7 @@ export function showProviderMessage(id: string, options: DisplayOptions) {
   return rpcMessage(RpcMessageType.showProvider, id, options);
 }
 
-export function saveMessage(id: string, credential: Credential) {
+export function saveMessage(id: string, credential: OYCredential) {
   return rpcMessage(RpcMessageType.save, id, credential);
 }
 

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -15,36 +15,28 @@
  */
 
 import {Credential, CredentialHintOptions, CredentialRequestOptions, ProxyLoginResponse} from './data';
-import {map2Enum} from './enums';
 import {OpenYoloErrorData, OpenYoloExtendedError} from './errors';
-import {isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
+import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
-export const RPC_MESSAGE_TYPES = map2Enum({
-  disableAutoSignIn: 'disableAutoSignIn',
-  disableAutoSignInResult: 'disableAutoSignInResult',
-  retrieve: 'retrieve',
-  hintAvailable: 'hintAvailable',
-  hintAvailableResult: 'hintAvailableResult',
-  hint: 'hint',
-  save: 'save',
-  saveResult: 'saveResult',
-  proxy: 'proxy',
-  proxyResult: 'proxyResult',
-  wrapBrowser: 'wrapBrowser',
-  wrapBrowserResult: 'wrapBrowserResult',
-  showProvider: 'showProvider',
-  none: 'none',
-  credential: 'credential',
-  error: 'error',
-  cancelLastOperation: 'cancelLastOperation',
-  cancelLastOperationResult: 'cancelLastOperationResult'
-});
-
-export type RpcMessageType = keyof typeof RPC_MESSAGE_TYPES;
-
-export interface RpcMessage<T extends RpcMessageType> {
-  type: T;
-  data: RpcMessageData<T>;
+export enum RpcMessageType {
+  disableAutoSignIn = 'disableAutoSignIn',
+  disableAutoSignInResult = 'disableAutoSignInResult',
+  retrieve = 'retrieve',
+  hintAvailable = 'hintAvailable',
+  hintAvailableResult = 'hintAvailableResult',
+  hint = 'hint',
+  save = 'save',
+  saveResult = 'saveResult',
+  proxy = 'proxy',
+  proxyResult = 'proxyResult',
+  wrapBrowser = 'wrapBrowser',
+  wrapBrowserResult = 'wrapBrowserResult',
+  showProvider = 'showProvider',
+  none = 'none',
+  credential = 'credential',
+  error = 'error',
+  cancelLastOperation = 'cancelLastOperation',
+  cancelLastOperationResult = 'cancelLastOperationResult'
 }
 
 export type RpcMessageArgumentTypes = {
@@ -68,29 +60,18 @@ export type RpcMessageArgumentTypes = {
   'cancelLastOperationResult': undefined
 };
 
-export type RpcMessageArgumentType<T extends RpcMessageType> =
-    RpcMessageArgumentTypes[T];
-
 export interface RpcMessageData<T extends RpcMessageType> {
   id: string;
   ack: boolean;
   args: RpcMessageArgumentTypes[T];
 }
 
-export type RpcMessageDataTypes = {
-  [K in RpcMessageType]: RpcMessageData<K>
-};
-
-export interface CredentialResponseData { credential: Credential; }
-
-export interface ErrorMessageData { error: OpenYoloErrorData; }
-
-export interface DisplayOptions {
-  height?: number;
-  width?: number;
+export interface RpcMessage<T extends RpcMessageType> {
+  type: T;
+  data: RpcMessageData<T>;
 }
 
-function rpcDataValidator(dataValidator: (data: any) => boolean) {
+function rpcDataValidator(dataValidator: DataValidator): DataValidator {
   return (data: any): boolean => {
     return !!data && typeof data === 'object' && 'id' in data &&
         typeof data['id'] === 'string' && dataValidator(data['args']);
@@ -98,7 +79,7 @@ function rpcDataValidator(dataValidator: (data: any) => boolean) {
 }
 
 export const RPC_MESSAGE_DATA_VALIDATORS:
-    {[K in RpcMessageType]: (data: any) => boolean} = {
+    {[K in RpcMessageType]: DataValidator} = {
       'disableAutoSignIn': rpcDataValidator(isUndefined),
       'disableAutoSignInResult': rpcDataValidator(isUndefined),
       'retrieve': rpcDataValidator(isValidRequestOptions),
@@ -119,6 +100,15 @@ export const RPC_MESSAGE_DATA_VALIDATORS:
       'cancelLastOperationResult': rpcDataValidator(isUndefined)
     };
 
+export interface CredentialResponseData { credential: Credential; }
+
+export interface ErrorMessageData { error: OpenYoloErrorData; }
+
+export interface DisplayOptions {
+  height?: number;
+  width?: number;
+}
+
 /* ****************************************************************************/
 /* ************************ MESSAGE CREATION FUNCTIONS ************************/
 /* ****************************************************************************/
@@ -129,76 +119,76 @@ export function rpcMessage<T extends RpcMessageType>(
 }
 
 export function disableAutoSignInMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.disableAutoSignIn, id, undefined);
+  return rpcMessage(RpcMessageType.disableAutoSignIn, id, undefined);
 }
 
 export function disableAutoSignInResultMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.disableAutoSignInResult, id, undefined);
+  return rpcMessage(RpcMessageType.disableAutoSignInResult, id, undefined);
 }
 
 export function retrieveMessage(id: string, options: CredentialRequestOptions) {
-  return rpcMessage(RPC_MESSAGE_TYPES.retrieve, id, options);
+  return rpcMessage(RpcMessageType.retrieve, id, options);
 }
 
 export function hintAvailableMessage(
     id: string, options: CredentialHintOptions) {
-  return rpcMessage(RPC_MESSAGE_TYPES.hintAvailable, id, options);
+  return rpcMessage(RpcMessageType.hintAvailable, id, options);
 }
 
 export function hintAvailableResponseMessage(id: string, available: boolean) {
-  return rpcMessage(RPC_MESSAGE_TYPES.hintAvailableResult, id, available);
+  return rpcMessage(RpcMessageType.hintAvailableResult, id, available);
 }
 
 export function hintMessage(id: string, options: CredentialHintOptions) {
-  return rpcMessage(RPC_MESSAGE_TYPES.hint, id, options);
+  return rpcMessage(RpcMessageType.hint, id, options);
 }
 
 export function proxyLoginMessage(id: string, credential: Credential) {
-  return rpcMessage(RPC_MESSAGE_TYPES.proxy, id, credential);
+  return rpcMessage(RpcMessageType.proxy, id, credential);
 }
 
 export function proxyLoginResponseMessage(
     id: string, response: ProxyLoginResponse) {
-  return rpcMessage(RPC_MESSAGE_TYPES.proxyResult, id, response);
+  return rpcMessage(RpcMessageType.proxyResult, id, response);
 }
 
 export function wrapBrowserMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.wrapBrowser, id, undefined);
+  return rpcMessage(RpcMessageType.wrapBrowser, id, undefined);
 }
 
 export function wrapBrowserResultMessage(id: string, wrapBrowser: boolean) {
   console.log(`wrapBrowserResult ${id} ${wrapBrowser}`);
-  return rpcMessage(RPC_MESSAGE_TYPES.wrapBrowserResult, id, wrapBrowser);
+  return rpcMessage(RpcMessageType.wrapBrowserResult, id, wrapBrowser);
 }
 
 export function noneAvailableMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.none, id, undefined);
+  return rpcMessage(RpcMessageType.none, id, undefined);
 }
 
 export function credentialResultMessage(id: string, credential: Credential) {
-  return rpcMessage(RPC_MESSAGE_TYPES.credential, id, credential);
+  return rpcMessage(RpcMessageType.credential, id, credential);
 }
 
 export function showProviderMessage(id: string, options: DisplayOptions) {
-  return rpcMessage(RPC_MESSAGE_TYPES.showProvider, id, options);
+  return rpcMessage(RpcMessageType.showProvider, id, options);
 }
 
 export function saveMessage(id: string, credential: Credential) {
-  return rpcMessage(RPC_MESSAGE_TYPES.save, id, credential);
+  return rpcMessage(RpcMessageType.save, id, credential);
 }
 
 export function saveResultMessage(id: string, saved: boolean) {
-  return rpcMessage(RPC_MESSAGE_TYPES.saveResult, id, saved);
+  return rpcMessage(RpcMessageType.saveResult, id, saved);
 }
 
 export function errorMessage(id: string, error: OpenYoloExtendedError) {
-  return rpcMessage(RPC_MESSAGE_TYPES.error, id, error.data);
+  return rpcMessage(RpcMessageType.error, id, error.data);
 }
 
 export function cancelLastOperationMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.cancelLastOperation, id, undefined);
+  return rpcMessage(RpcMessageType.cancelLastOperation, id, undefined);
 }
 
 export function cancelLastOperationResultMessage(id: string) {
-  return rpcMessage(RPC_MESSAGE_TYPES.cancelLastOperationResult, id, undefined);
+  return rpcMessage(RpcMessageType.cancelLastOperationResult, id, undefined);
 }

--- a/ts/protocol/secure_channel_test.ts
+++ b/ts/protocol/secure_channel_test.ts
@@ -19,7 +19,7 @@ import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent, createUntypedMessageEvent} from '../test_utils/messages';
 import {JasmineTimeoutManager} from '../test_utils/timeout';
 
-import {ERROR_TYPES, OpenYoloError} from './errors';
+import {InternalErrorCode, OpenYoloError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, readyForConnectMessage} from './post_messages';
 import * as msg from './rpc_messages';
 import {SecureChannel} from './secure_channel';
@@ -84,8 +84,9 @@ describe('SecureChannel', () => {
               },
               (err: Error) => {
                 expect(expectReject).toBeTruthy('Failed before timeout');
-                expect(OpenYoloError.errorIs(
-                           err, ERROR_TYPES.establishSecureChannelTimeout))
+                expect(
+                    OpenYoloError.errorIs(
+                        err, InternalErrorCode.establishSecureChannelTimeout))
                     .toBeTruthy();
                 done();
               });
@@ -122,8 +123,8 @@ describe('SecureChannel', () => {
     it('adds and removes listener', () => {
       let listener1 = jasmine.createSpy('listener1');
       let listener2 = jasmine.createSpy('listener2');
-      let listenerKey1 = channel.listen(msg.RPC_MESSAGE_TYPES.none, listener1);
-      let listenerKey2 = channel.listen(msg.RPC_MESSAGE_TYPES.none, listener2);
+      let listenerKey1 = channel.listen(msg.RpcMessageType.none, listener1);
+      let listenerKey2 = channel.listen(msg.RpcMessageType.none, listener2);
 
       port.dispatchEvent(createMessageEvent(msg.noneAvailableMessage('123')));
 
@@ -168,7 +169,7 @@ describe('SecureChannel', () => {
             },
             (err) => {
               expect(expectReject).toBeTruthy('Failed before timeout');
-              expect(OpenYoloError.errorIs(err, ERROR_TYPES.ackTimeout))
+              expect(OpenYoloError.errorIs(err, InternalErrorCode.ackTimeout))
                   .toBeTruthy();
               expect(port.removeEventListener)
                   .toHaveBeenCalledWith('message', jasmine.any(Function));
@@ -183,7 +184,7 @@ describe('SecureChannel', () => {
 
       it('sends back ack when required', () => {
         const listener1 = jasmine.createSpy('listener1');
-        channel.listen(msg.RPC_MESSAGE_TYPES.none, listener1);
+        channel.listen(msg.RpcMessageType.none, listener1);
 
         const message = msg.noneAvailableMessage('123');
         message.data.ack = true;
@@ -197,8 +198,8 @@ describe('SecureChannel', () => {
       it('removes listeners and closes', () => {
         let listener1 = jasmine.createSpy('listener1');
         let listener2 = jasmine.createSpy('listener2');
-        channel.listen(msg.RPC_MESSAGE_TYPES.credential, listener1);
-        channel.listen(msg.RPC_MESSAGE_TYPES.credential, listener2);
+        channel.listen(msg.RpcMessageType.credential, listener1);
+        channel.listen(msg.RpcMessageType.credential, listener2);
         channel.dispose();
 
         // internally, only a single listener is added to a port, so we only

--- a/ts/protocol/validators.ts
+++ b/ts/protocol/validators.ts
@@ -16,6 +16,8 @@
 
 import {getPath, isHierarchical, parseUri} from './uri';
 
+export type DataValidator = (data?: any) => boolean;
+
 export function isUndefined(value?: any): boolean {
   return typeof value === 'undefined';
 }

--- a/ts/spi/ancestor_origin_verifier.ts
+++ b/ts/spi/ancestor_origin_verifier.ts
@@ -16,7 +16,7 @@
 
 import {createMessageListener, isPermittedOrigin, sendMessage, WindowLike} from '../protocol/comms';
 import {OpenYoloError} from '../protocol/errors';
-import {POST_MESSAGE_TYPES, verifyPingMessage} from '../protocol/post_messages';
+import {PostMessageType, verifyPingMessage} from '../protocol/post_messages';
 import {generateId, TimeoutPromiseResolver} from '../protocol/utils';
 
 export interface MessageEventLike {
@@ -125,8 +125,8 @@ export class AncestorOriginVerifier {
 
     let verifyId: string = generateId();
 
-    let listener = createMessageListener(
-        POST_MESSAGE_TYPES.verifyAck, (data, type, ev) => {
+    let listener =
+        createMessageListener(PostMessageType.verifyAck, (data, type, ev) => {
           // ignore the message if it doesn't contain the correct verification
           // ID, or is from the wrong frame.
           if (data !== verifyId || ev.source !== ancestorFrame) {

--- a/ts/spi/ancestor_origin_verifier_test.ts
+++ b/ts/spi/ancestor_origin_verifier_test.ts
@@ -15,7 +15,7 @@
  */
 
 import {OpenYoloError} from '../protocol/errors';
-import {POST_MESSAGE_TYPES, verifyAckMessage, verifyPingMessage} from '../protocol/post_messages';
+import {PostMessageType, verifyAckMessage, verifyPingMessage} from '../protocol/post_messages';
 import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent} from '../test_utils/messages';
 import {JasmineTimeoutManager} from '../test_utils/timeout';
@@ -61,10 +61,8 @@ describe('AncestorOriginVerifier', () => {
       // the verification message should be sent
       expect(postMessageSpy)
           .toHaveBeenCalledWith(
-              jasmine.objectContaining({
-                type: POST_MESSAGE_TYPES.verifyPing,
-                data: jasmine.anything()
-              }),
+              jasmine.objectContaining(
+                  {type: PostMessageType.verifyPing, data: jasmine.anything()}),
               '*');
     });
 
@@ -91,7 +89,7 @@ describe('AncestorOriginVerifier', () => {
       let parentOrigin = permittedOrigins[0];
 
       parentFrame.addEventListener('message', (ev: MessageEvent) => {
-        expect(ev.data.type).toBe(POST_MESSAGE_TYPES.verifyPing);
+        expect(ev.data.type).toBe(PostMessageType.verifyPing);
         // simulate the response message from the valid parent origin, and
         // with the received nonce value
         providerFrame.postMessageFromOrigin(
@@ -109,7 +107,7 @@ describe('AncestorOriginVerifier', () => {
 
          let pingReceived = false;
          parentFrame.addEventListener('message', (ev: MessageEvent) => {
-           expect(ev.data.type).toBe(POST_MESSAGE_TYPES.verifyPing);
+           expect(ev.data.type).toBe(PostMessageType.verifyPing);
            pingReceived = true;
            // simulate the response message from the wrong origin
            providerFrame.postMessageFromOrigin(
@@ -131,7 +129,7 @@ describe('AncestorOriginVerifier', () => {
       let parentOrigin = permittedOrigins[0];
 
       parentFrame.addEventListener('message', (ev: MessageEvent) => {
-        expect(ev.data.type).toBe(POST_MESSAGE_TYPES.verifyPing);
+        expect(ev.data.type).toBe(PostMessageType.verifyPing);
         // simulate the response message from the valid parent origin,
         // but with a different nonce
         providerFrame.postMessageFromOrigin(
@@ -156,7 +154,7 @@ describe('AncestorOriginVerifier', () => {
       let parentOrigin = permittedOrigins[0];
 
       parentFrame.addEventListener('message', (ev: MessageEvent) => {
-        expect(ev.data.type).toBe(POST_MESSAGE_TYPES.verifyPing);
+        expect(ev.data.type).toBe(PostMessageType.verifyPing);
         // simulate the response message from the valid parent origin,
         // but with another ping instead of an ack
         providerFrame.postMessageFromOrigin(
@@ -180,7 +178,7 @@ describe('AncestorOriginVerifier', () => {
 
          let pingReceived = false;
          parentFrame.addEventListener('message', (ev: MessageEvent) => {
-           expect(ev.data.type).toBe(POST_MESSAGE_TYPES.verifyPing);
+           expect(ev.data.type).toBe(PostMessageType.verifyPing);
            pingReceived = true;
            // simulate the response message from the valid parent origin,
            // but with a source that is not the provider frame

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -15,7 +15,7 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {Credential, CredentialHintOptions} from '../protocol/data';
+import {Credential, CredentialHintOptions, CredentialRequestOptions} from '../protocol/data';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 /**
@@ -90,7 +90,8 @@ export interface ClientConfigurationProvider {
   /**
    * Returns the client configuration for the specified domain, if available.
    */
-  getConfiguration(authDomain: string): Promise<PrimaryClientConfiguration>;
+  getConfiguration(authDomain: string):
+      Promise<PrimaryClientConfiguration|null>;
 }
 
 /**

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -15,7 +15,7 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {Credential, CredentialHintOptions, CredentialRequestOptions} from '../protocol/data';
+import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions} from '../protocol/data';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 /**
@@ -102,27 +102,27 @@ export interface CredentialDataProvider {
   /**
    * Retrieves all hint credentials, based upon the provided options.
    */
-  getAllHints(options: CredentialHintOptions): Promise<Credential[]>;
+  getAllHints(options: OYCredentialHintOptions): Promise<OYCredential[]>;
 
   /**
    * Retrieves all credentials for the specified authentication domains
    * (derived from the request) and the specified request options.
    */
-  getAllCredentials(authDomains: string[], options: CredentialRequestOptions):
-      Promise<Credential[]>;
+  getAllCredentials(authDomains: string[], options: OYCredentialRequestOptions):
+      Promise<OYCredential[]>;
 
   /**
    * Creates or updates an existing credential. If the credential cannot be
    * created or updated, the promise should be rejected.
    */
-  upsertCredential(credential: Credential, original?: Credential):
-      Promise<Credential>;
+  upsertCredential(credential: OYCredential, original?: OYCredential):
+      Promise<OYCredential>;
 
   /**
    * Deletes the provided credential from the store. If delete is not
    * permitted for this credential, the returned promise will be rejected.
    */
-  deleteCredential(credential: Credential): Promise<void>;
+  deleteCredential(credential: OYCredential): Promise<void>;
 }
 
 export interface DisplayCallbacks {
@@ -139,9 +139,9 @@ export interface InteractionProvider {
    * or reject if the action is cancelled or fails for any reason.
    */
   showCredentialPicker(
-      credentials: Credential[],
-      options: CredentialRequestOptions,
-      displayCallbacks: DisplayCallbacks): Promise<Credential>;
+      credentials: OYCredential[],
+      options: OYCredentialRequestOptions,
+      displayCallbacks: DisplayCallbacks): Promise<OYCredential>;
 
   /**
    * Requests the display of a hint picker containing the provided list of
@@ -150,9 +150,9 @@ export interface InteractionProvider {
    * not select a credential, the promise should be rejected.
    */
   showHintPicker(
-      hints: Credential[],
-      options: CredentialHintOptions,
-      displayCallbacks: DisplayCallbacks): Promise<Credential>;
+      hints: OYCredential[],
+      options: OYCredentialHintOptions,
+      displayCallbacks: DisplayCallbacks): Promise<OYCredential>;
 
   /**
    * Requests the display of a confirmation screen, allowing the user to
@@ -161,14 +161,14 @@ export interface InteractionProvider {
    * credential, false otherwise.
    */
   showSaveConfirmation(
-      credential: Credential,
+      credential: OYCredential,
       displayCallbacks: DisplayCallbacks): Promise<boolean>;
 
   /**
    * Requests the display of an auto sign in screen. The promise should always
    * resolve, as no action is required.
    */
-  showAutoSignIn(credential: Credential, displayCallbacks: DisplayCallbacks):
+  showAutoSignIn(credential: OYCredential, displayCallbacks: DisplayCallbacks):
       Promise<any>;
 
   /**
@@ -205,7 +205,7 @@ export interface LocalStateProvider {
    * timescale equivalent to what sessionStorage provides - not permanent, but
    * able to survive page turns / reinstantiation of the provider frame.
    */
-  retainCredentialForSession(authDomain: string, credential: Credential):
+  retainCredentialForSession(authDomain: string, credential: OYCredential):
       Promise<void>;
 
   /**
@@ -218,5 +218,5 @@ export interface LocalStateProvider {
    * of this interface, such that subsequent calls to this method for the same
    * domain would also return a rejected promise.
    */
-  getRetainedCredential(authDomain: string): Promise<Credential>;
+  getRetainedCredential(authDomain: string): Promise<OYCredential>;
 }

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -54,7 +54,7 @@ export class ProviderFrame {
       let clientConfiguration =
           await providerConfig.clientConfigurationProvider.getConfiguration(
               providerConfig.clientAuthDomain);
-      if (!clientConfiguration.apiEnabled) {
+      if (!clientConfiguration || !clientConfiguration.apiEnabled) {
         console.info('OpenYOLO API is not enabled for the client origin');
         throw OpenYoloError.apiDisabled();
       }
@@ -424,7 +424,7 @@ export class ProviderFrame {
       return;
     }
 
-    let type = (ev.data.type as msg.RpcMessageType);
+    const type = (ev.data.type as msg.RpcMessageType);
 
     if (!msg.RPC_MESSAGE_DATA_VALIDATORS[type](ev.data.data)) {
       console.warn(
@@ -433,7 +433,7 @@ export class ProviderFrame {
       return;
     }
 
-    let data = (ev.data.data as msg.RpcMessageData<any>);
+    const data = (ev.data.data as msg.RpcMessageData<any>);
     // the message is a known, valid, but unhandled RPC message. Send a generic
     // failure message back.
     this.clientChannel.send(
@@ -610,7 +610,7 @@ export class ProviderFrame {
     if (!this.cancellable) {
       this.cancellable = new CancellablePromise();
     }
-    return Promise.race([this.cancellable.promise, producer]);
+    return Promise.race([this.cancellable.promise, producer]) as Promise<T>;
   }
 
   private handleWellKnownErrors(error: Error) {

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -145,35 +145,34 @@ export class ProviderFrame {
 
   private registerListeners() {
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.wrapBrowser,
+        msg.RpcMessageType.wrapBrowser,
         (m) => this.handleWrapBrowserRequest(m.id));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.disableAutoSignIn,
+        msg.RpcMessageType.disableAutoSignIn,
         (m) => this.handleDisableAutoSignInRequest(m.id));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.retrieve,
+        msg.RpcMessageType.retrieve,
         (m) => this.handleGetCredentialRequest(m.id, m.args));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.hint,
-        (m) => this.handleHintRequest(m.id, m.args));
+        msg.RpcMessageType.hint, (m) => this.handleHintRequest(m.id, m.args));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.hintAvailable,
+        msg.RpcMessageType.hintAvailable,
         (m) => this.handleHintAvailableRequest(m.id, m.args));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.save,
+        msg.RpcMessageType.save,
         (m) => this.handleSaveCredentialRequest(m.id, m.args));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.proxy,
+        msg.RpcMessageType.proxy,
         (m) => this.handleProxyLoginRequest(m.id, m.args));
 
     this.addRpcListener(
-        msg.RPC_MESSAGE_TYPES.cancelLastOperation,
+        msg.RpcMessageType.cancelLastOperation,
         (m) => this.handleCancelLastOperation(m.id));
 
     this.clientChannel.addFallbackListener((ev) => {
@@ -184,17 +183,17 @@ export class ProviderFrame {
 
   private addRpcListener<T extends msg.RpcMessageType>(
       type: T,
-      messageHandler: (message: msg.RpcMessageDataTypes[T]) => Promise<void>) {
+      messageHandler: (message: msg.RpcMessageData<T>) => Promise<void>) {
     this.clientChannel.listen<T>(
         type,
-        (m: msg.RpcMessageDataTypes[T], type: T, ev: MessageEvent) =>
+        (m: msg.RpcMessageData<T>, type: T, ev: MessageEvent) =>
             this.monitoringListener(type, m, messageHandler));
   }
 
   private async monitoringListener<T extends msg.RpcMessageType>(
       type: T,
-      m: msg.RpcMessageDataTypes[T],
-      messageHandler: (message: msg.RpcMessageDataTypes[T]) => Promise<void>) {
+      m: msg.RpcMessageData<T>,
+      messageHandler: (message: msg.RpcMessageData<T>) => Promise<void>) {
     if (!this.recordRequestStart(type, m.id)) {
       return;
     }
@@ -320,7 +319,7 @@ export class ProviderFrame {
             this.equivalentAuthDomains, options));
 
     // filter out the credentials which don't match the request options
-    let pertinentCredentials = credentials.filter((credential) => {
+    let pertinentCredentials = credentials.filter((credential: Credential) => {
       return options.supportedAuthMethods.find(
           (value) => value === credential.authMethod);
     });
@@ -378,12 +377,12 @@ export class ProviderFrame {
       id: string,
       credential: Credential) {
     // TODO(iainmcgin): implement
-    return this.handleUnimplementedRequest(id, msg.RPC_MESSAGE_TYPES.save);
+    return this.handleUnimplementedRequest(id, msg.RpcMessageType.save);
   }
 
   private async handleProxyLoginRequest(id: string, credential: Credential) {
     // TODO(iainmcgin): implement
-    return this.handleUnimplementedRequest(id, msg.RPC_MESSAGE_TYPES.proxy);
+    return this.handleUnimplementedRequest(id, msg.RpcMessageType.proxy);
   }
 
   private async handleCancelLastOperation(id: string) {
@@ -420,7 +419,7 @@ export class ProviderFrame {
       return;
     }
 
-    if (!(ev.data.type in msg.RPC_MESSAGE_TYPES)) {
+    if (!(ev.data.type in msg.RpcMessageType)) {
       console.warn('Non-RPC message received on secure channel, ignoring');
       return;
     }

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -15,7 +15,7 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {AUTHENTICATION_METHODS, Credential, CredentialHintOptions, CredentialRequestOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions} from '../protocol/data';
 import {OpenYoloError} from '../protocol/errors';
 import * as msg from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
@@ -46,11 +46,11 @@ describe('ProviderFrame', () => {
 
   let frameConfig: ProviderConfiguration;
 
-  let alicePwdCred: Credential;
-  let bobPwdCred: Credential;
-  let carlGoogCred: Credential;
-  let deliaFbCred: Credential;
-  let elisaOtherDomainCred: Credential;
+  let alicePwdCred: OYCredential;
+  let bobPwdCred: OYCredential;
+  let carlGoogCred: OYCredential;
+  let deliaFbCred: OYCredential;
+  let elisaOtherDomainCred: OYCredential;
 
   let timeoutManager = new JasmineTimeoutManager();
 
@@ -283,7 +283,7 @@ describe('ProviderFrame', () => {
 
     describe('handling credential retrieval', () => {
 
-      let passwordOnlyRequest: CredentialRequestOptions = {
+      let passwordOnlyRequest: OYCredentialRequestOptions = {
         supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
       };
 
@@ -301,7 +301,7 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showAutoSignIn as jasmine.Spy)
                .and.callFake(
-                   (credential: Credential,
+                   (credential: OYCredential,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credential).toBe(alicePwdCred);
                      return Promise.resolve();
@@ -322,7 +322,7 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showAutoSignIn as jasmine.Spy)
             .and.callFake(
-                (credential: Credential,
+                (credential: OYCredential,
                  displayCallbacks: DisplayCallbacks) => {
                   expect(credential).toBe(alicePwdCred);
                   // return a promise that's not going to resolve
@@ -381,8 +381,8 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: Credential[],
-                    options: CredentialRequestOptions,
+                   (credentials: OYCredential[],
+                    options: OYCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credentials).toEqual([alicePwdCred]);
                      expect(options).toBeDefined();
@@ -418,8 +418,8 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showCredentialPicker as jasmine.Spy)
             .and.callFake(
-                (credentials: Credential[],
-                 options: CredentialRequestOptions,
+                (credentials: OYCredential[],
+                 options: OYCredentialRequestOptions,
                  displayCallbacks: DisplayCallbacks) => {
                   displayCallbacks.requestDisplayOptions(uiConfig).then(done);
                 });
@@ -436,8 +436,8 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: Credential[],
-                    options: CredentialRequestOptions,
+                   (credentials: OYCredential[],
+                    options: OYCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credentials).toEqual([alicePwdCred, bobPwdCred]);
                      expect(options).toBeDefined();
@@ -466,8 +466,8 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: Credential[],
-                    options: CredentialRequestOptions,
+                   (credentials: OYCredential[],
+                    options: OYCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expectFinalResult = true;
                      return Promise.reject(OpenYoloError.canceled());
@@ -527,7 +527,7 @@ describe('ProviderFrame', () => {
     });
 
     // tests can use this to emulate user interaction in the credential picker
-    const pwdOrFbHintOptions: CredentialHintOptions = {
+    const pwdOrFbHintOptions: OYCredentialHintOptions = {
       supportedAuthMethods: [
         AUTHENTICATION_METHODS.ID_AND_PASSWORD,
         AUTHENTICATION_METHODS.FACEBOOK
@@ -587,8 +587,8 @@ describe('ProviderFrame', () => {
       // this is checked for as a follow-up message, otherwise a pick cancel
       // message is expected.
       function expectPickFromHints(
-          expectedHints: Credential[],
-          selection: Credential|null,
+          expectedHints: OYCredential[],
+          selection: OYCredential|null,
           expectedResult: msg.RpcMessage<msg.RpcMessageType.credential>|
           msg.RpcMessage<msg.RpcMessageType.none>,
           neverResolve: boolean = false) {
@@ -597,8 +597,8 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showHintPicker as jasmine.Spy)
             .and.callFake(
-                (hints: Credential[],
-                 options: CredentialHintOptions,
+                (hints: OYCredential[],
+                 options: OYCredentialHintOptions,
                  displayCallbacks: DisplayCallbacks) => {
                   expect(hints).toEqual(expectedHints);
                   expect(options).toBeDefined();
@@ -666,7 +666,7 @@ describe('ProviderFrame', () => {
 
       it('should return selected hint', async function(done) {
         credentialDataProvider.credentials = [elisaOtherDomainCred];
-        let redactedElisaCred: Credential = {
+        let redactedElisaCred: OYCredential = {
           id: elisaOtherDomainCred.id,
           authMethod: elisaOtherDomainCred.authMethod,
           authDomain: TEST_AUTH_DOMAIN
@@ -735,7 +735,7 @@ describe('ProviderFrame', () => {
          });
 
       it('should prioritize hints with a display name', async function(done) {
-        let deliaFbCredWithName: Credential = {
+        let deliaFbCredWithName: OYCredential = {
           id: deliaFbCred.id,
           authMethod: deliaFbCred.authMethod,
           authDomain: deliaFbCred.authDomain,
@@ -751,7 +751,7 @@ describe('ProviderFrame', () => {
 
       it('should prioritize hints with a profile picture',
          async function(done) {
-           let deliaFbCredWithPicture: Credential = {
+           let deliaFbCredWithPicture: OYCredential = {
              id: deliaFbCred.id,
              authMethod: deliaFbCred.authMethod,
              authDomain: deliaFbCred.authDomain,
@@ -820,15 +820,15 @@ class TestClientConfigurationProvider implements ClientConfigurationProvider {
 }
 
 class TestCredentialDataProvider implements CredentialDataProvider {
-  credentials: Credential[] = [];
+  credentials: OYCredential[] = [];
   neverSave: {[key: string]: boolean} = {};
 
-  async getAllCredentials(authDomains: string[]): Promise<Credential[]> {
+  async getAllCredentials(authDomains: string[]): Promise<OYCredential[]> {
     if (authDomains.length < 1) {
       return this.credentials;
     }
 
-    let filteredCredentials: Credential[] = [];
+    let filteredCredentials: OYCredential[] = [];
 
     for (let i = 0; i < this.credentials.length; i++) {
       let credential = this.credentials[i];
@@ -841,7 +841,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
     return filteredCredentials;
   }
 
-  async getAllHints(options: CredentialHintOptions): Promise<Credential[]> {
+  async getAllHints(options: OYCredentialHintOptions): Promise<OYCredential[]> {
     // no filtering required in the hints case
     return this.credentials;
   }
@@ -869,15 +869,15 @@ class TestCredentialDataProvider implements CredentialDataProvider {
   /**
    * Determines whether the provided credential can be saved to this store.
    */
-  async canSave(credential: Credential): Promise<boolean> {
+  async canSave(credential: OYCredential): Promise<boolean> {
     return true;
   }
 
   /**
    * Creates or updates an existing credential.
    */
-  async upsertCredential(credential: Credential, original?: Credential):
-      Promise<Credential> {
+  async upsertCredential(credential: OYCredential, original?: OYCredential):
+      Promise<OYCredential> {
     if (original) {
       await this.deleteCredential(original);
     }
@@ -888,7 +888,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
   /**
    * Determines whether the provided credential can be deleted.
    */
-  async canDelete(credential: Credential): Promise<boolean> {
+  async canDelete(credential: OYCredential): Promise<boolean> {
     return true;
   }
 
@@ -896,7 +896,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
    * Deletes the provided credential from the store. If delete is not
    * permitted for this credential, the returned promise will be rejected.
    */
-  async deleteCredential(credential: Credential): Promise<void> {
+  async deleteCredential(credential: OYCredential): Promise<void> {
     let existing = this.credentials.findIndex(
         (c) => c.authDomain === credential.authDomain &&
             c.id === credential.id && c.authMethod === credential.authMethod);
@@ -911,7 +911,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
 
 class TestLocalStateProvider implements LocalStateProvider {
   autoSignIn: {[label: string]: boolean} = {};
-  retained: {[authDomain: string]: Credential} = {};
+  retained: {[authDomain: string]: OYCredential} = {};
 
   async isAutoSignInEnabled(authDomain: string): Promise<boolean> {
     let result: boolean;
@@ -928,11 +928,13 @@ class TestLocalStateProvider implements LocalStateProvider {
     this.autoSignIn[authDomain] = enabled;
   }
 
-  async retainCredentialForSession(authDomain: string, credential: Credential) {
+  async retainCredentialForSession(
+      authDomain: string,
+      credential: OYCredential) {
     this.retained[authDomain] = credential;
   }
 
-  async getRetainedCredential(authDomain: string): Promise<Credential> {
+  async getRetainedCredential(authDomain: string): Promise<OYCredential> {
     if (this.retained[authDomain]) {
       let credential = this.retained[authDomain];
       delete this.retained[authDomain];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,21 +3,23 @@
 
 
 "@angular/animations@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.1.1.tgz#1000f8b22dc2031a8c36d225eb2dcf5f6c0d0af5"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.3.0.tgz#56f34b84649379202ac359929b82eb0b915e9c72"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/cli@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-1.0.2.tgz#68f37cea8b379521120bb83032e76ac623b9917c"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-1.2.1.tgz#2b50f907c8a58b4b17a543d8da75559fb3c35309"
   dependencies:
-    "@ngtools/json-schema" "1.0.9"
-    "@ngtools/webpack" "1.3.1"
+    "@ngtools/json-schema" "1.1.0"
+    "@ngtools/webpack" "1.5.1"
     autoprefixer "^6.5.3"
     chalk "^1.1.3"
     common-tags "^1.3.1"
-    css-loader "^0.27.3"
+    core-object "^3.1.0"
+    css-loader "^0.28.1"
     cssnano "^3.10.0"
-    debug "^2.1.3"
     denodeify "^1.2.1"
     diff "^3.1.0"
     ember-cli-normalize-entity-name "^1.0.0"
@@ -25,20 +27,22 @@
     exports-loader "^0.6.3"
     extract-text-webpack-plugin "^2.1.0"
     file-loader "^0.10.0"
-    fs-extra "^2.0.0"
+    fs-extra "^3.0.1"
     get-caller-file "^1.0.0"
     glob "^7.0.3"
+    heimdalljs "^0.2.4"
+    heimdalljs-logger "^0.1.9"
     html-webpack-plugin "^2.19.0"
     inflection "^1.7.0"
     inquirer "^3.0.0"
     isbinaryfile "^3.0.0"
     istanbul-instrumenter-loader "^2.0.0"
     json-loader "^0.5.4"
-    karma-sourcemap-loader "^0.3.7"
-    karma-webpack "^2.0.0"
     less "^2.7.2"
     less-loader "^4.0.2"
+    license-webpack-plugin "^0.4.2"
     lodash "^4.11.1"
+    memory-fs "^0.4.1"
     minimatch "^3.0.3"
     node-modules-path "^1.0.0"
     nopt "^4.0.1"
@@ -48,85 +52,103 @@
     postcss-url "^5.1.2"
     raw-loader "^0.5.1"
     resolve "^1.1.7"
-    rimraf "^2.5.3"
     rsvp "^3.0.17"
     rxjs "^5.0.1"
     sass-loader "^6.0.3"
     script-loader "^0.7.0"
     semver "^5.1.0"
     silent-error "^1.0.0"
-    source-map-loader "^0.1.5"
+    source-map-loader "^0.2.0"
     style-loader "^0.13.1"
     stylus "^0.54.5"
     stylus-loader "^3.0.1"
     temp "0.8.3"
-    typescript ">=2.0.0 <2.3.0"
+    typescript ">=2.0.0 <2.4.0"
     url-loader "^0.5.7"
     walk-sync "^0.3.1"
-    webpack "~2.2.0"
-    webpack-dev-server "~2.4.2"
+    webpack "~2.4.0"
+    webpack-dev-middleware "^1.10.2"
+    webpack-dev-server "~2.4.5"
     webpack-merge "^2.4.0"
     zone.js "^0.8.4"
   optionalDependencies:
     node-sass "^4.3.0"
 
 "@angular/common@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.1.1.tgz#088a13a70c5390c5c9613aa05754b74ee18e1afb"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.3.0.tgz#13a54a6929dd52f9729b16ae446fad58fe163053"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/compiler-cli@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.1.1.tgz#8cea89ee12129c3f0edb55853e18b37b164f2953"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.3.0.tgz#f375809730f5e883cfe211ae991210f1cb1a9f1e"
   dependencies:
-    "@angular/tsc-wrapped" "4.1.1"
+    "@angular/tsc-wrapped" "4.3.0"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
 
 "@angular/compiler@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.1.1.tgz#fc62459056465f624c3ac6f68dadcc9ba74c4ae0"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.3.0.tgz#55503bf27a1f062f71b9495393f3311903a8fc43"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/core@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.1.1.tgz#1230645c842f8a6a050403d4947f982e7ef70c60"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.3.0.tgz#bd2249c3de1224a7c6536c4aba728d6565329334"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/forms@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.1.1.tgz#6af39f7c416e9f038c39f7ee5bfa51d9da550bf0"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.3.0.tgz#7d0c7a854737e9a30a5fd9665f8d4f56a1b91bd8"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/http@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.1.1.tgz#1e052d02e52aee7b48d1de626abbf067e850a242"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.3.0.tgz#dfb73310a840a6ad8050ac51f0e55c4984db0926"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/material@^2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.3.tgz#ec31dee61d7300ece28fee476852db236ded1e13"
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.8.tgz#a92852abc9261aea26c2401f576645470be2cf38"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.1.1.tgz#682881035140e22d498abca139907aa8187f6bfa"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.3.0.tgz#551fb18851b27ee8f3e4b0ee25aad10bd7b312e3"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.1.1.tgz#e2f545b458e7858cc0b20b0ae4cc99237560fb72"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.3.0.tgz#02389489185185c3becf06359346100e5479c7e1"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/router@>=4.0.0-beta <5.0.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-4.1.1.tgz#0a7ce03065197982786782cf5429fa6f0c0300fa"
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-4.3.0.tgz#71b428f185eb9161a1de14dc1949219ddcdffdae"
+  dependencies:
+    tslib "^1.7.1"
 
-"@angular/tsc-wrapped@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.1.1.tgz#ade793cdbe64c650c5f5946ff424c6a3577b09d8"
+"@angular/tsc-wrapped@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.3.0.tgz#fe2e5376b6e2ad1b139edde23a9dbb4299df6264"
   dependencies:
     tsickle "^0.21.0"
 
-"@ngtools/json-schema@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@ngtools/json-schema/-/json-schema-1.0.9.tgz#19e46db409c66b4c43841eab514ff9640871affc"
+"@ngtools/json-schema@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ngtools/json-schema/-/json-schema-1.1.0.tgz#c3a0c544d62392acc2813a42c8a0dc6f58f86922"
 
-"@ngtools/webpack@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.3.1.tgz#12149b6b9cb3bf858f4b2ae9650456e17674d2eb"
+"@ngtools/webpack@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.5.1.tgz#6b00ed8bfb6706ab0672b93d294e9e15f69e19be"
   dependencies:
     enhanced-resolve "^3.1.0"
     loader-utils "^1.0.2"
@@ -134,12 +156,12 @@
     source-map "^0.5.6"
 
 "@types/jasmine@^2.5.43":
-  version "2.5.47"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.47.tgz#bbba9bcf0e95e7890c6f4a47394e8bacaa960eb6"
+  version "2.5.53"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.53.tgz#4e0cefad09df5ec48c8dd40433512f84b1568d61"
 
 "@types/node@^6.0.46":
-  version "6.0.73"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.73.tgz#85dc4bb6f125377c75ddd2519a1eeb63f0a4ed70"
+  version "6.0.84"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.84.tgz#193ffe5a9f42864d425ffd9739d95b753c6a1eab"
 
 "@types/q@^0.0.32":
   version "0.0.32"
@@ -179,8 +201,12 @@ acorn-dynamic-import@^2.0.0:
     acorn "^4.0.3"
 
 acorn@^4.0.3, acorn@^4.0.4:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
 adm-zip@0.4.4:
   version "0.4.4"
@@ -195,8 +221,8 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
 agent-base@2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.0.1.tgz#bd8f9e86a8eb221fffa07bd14befd55df142815e"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
   dependencies:
     extend "~3.0.0"
     semver "~5.0.1"
@@ -205,11 +231,20 @@ ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv@^4.11.2, ajv@^4.7.0, ajv@^4.9.1:
+ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
+ajv@^5.0.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -234,9 +269,9 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -246,9 +281,19 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
 
 any-promise@^1.3.0:
   version "1.3.0"
@@ -266,8 +311,8 @@ app-root-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 aproba@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
 
 archiver-utils@^1.3.0:
   version "1.3.0"
@@ -318,8 +363,8 @@ arr-diff@^2.0.0:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -360,8 +405,8 @@ arrify@^1.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asap@~2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
   version "4.9.1"
@@ -411,13 +456,13 @@ async@2.0.1:
   dependencies:
     lodash "^4.8.0"
 
-async@^0.9.0, async@~0.9.0:
+async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
 async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.1.5:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
 
@@ -457,12 +502,12 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
     js-tokens "^3.0.0"
 
 babel-generator@^6.18.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
+    babel-types "^6.25.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.2.0"
@@ -483,65 +528,69 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     regenerator-runtime "^0.10.0"
 
 babel-template@^6.16.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
   dependencies:
     babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
+babel-traverse@^6.18.0, babel-traverse@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
     babel-code-frame "^6.22.0"
     babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    babylon "^6.15.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+babel-types@^6.18.0, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
-  version "6.17.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
+babylon@^6.17.2, babylon@^6.17.4:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
-balanced-match@^0.4.1, balanced-match@^0.4.2:
+balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
 base64-js@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
 base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
-batch@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/batch/-/batch-0.5.3.tgz#3f3414f380321743bfc1042f9a83ff1d5824d464"
+batch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -594,23 +643,23 @@ bluebird@^3.0.5, bluebird@^3.3.0, bluebird@^3.4.7:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
+  version "4.11.7"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
 
 body-parser@^1.16.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.1.tgz#75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47"
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.2.tgz#f8892abc8f9e627d42aedafbca66bf5ab99104ee"
   dependencies:
     bytes "2.4.0"
     content-type "~1.0.2"
-    debug "2.6.1"
+    debug "2.6.7"
     depd "~1.1.0"
     http-errors "~1.6.1"
     iconv-lite "0.4.15"
     on-finished "~2.3.0"
     qs "6.4.0"
     raw-body "~2.2.0"
-    type-is "~1.6.14"
+    type-is "~1.6.15"
 
 boolbase@~1.0.0:
   version "1.0.0"
@@ -623,22 +672,22 @@ boom@2.x.x:
     hoek "2.x.x"
 
 boxen@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.1.0.tgz#b1b69dd522305e807a99deee777dbd6e5167b102"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.2.0.tgz#03478d84be7fe02189b80904d81d6a80384368f1"
   dependencies:
     ansi-align "^2.0.0"
     camelcase "^4.0.0"
-    chalk "^1.1.1"
+    chalk "^2.0.1"
     cli-boxes "^1.0.0"
     string-width "^2.0.0"
-    term-size "^0.1.0"
+    term-size "^1.2.0"
     widest-line "^1.0.0"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^0.1.2:
@@ -727,10 +776,6 @@ buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
-buffer-shims@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
 buffer-xor@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -751,13 +796,13 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bytes@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
-
 bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
+bytes@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
 
 callsite@1.0.0:
   version "1.0.0"
@@ -803,8 +848,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000666"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000666.tgz#951ed9f3d3bfaa08a06dafbb5089ab07cce6ab90"
+  version "1.0.30000702"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000702.tgz#a60cd30f3ef44ae7b5ed12e9d9b70d4bff6352cb"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -835,7 +880,15 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.4.1, chokidar@^1.4.3, chokidar@^1.6.0:
+chalk@^2.0.0, chalk@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chokidar@^1.4.1, chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -850,29 +903,30 @@ chokidar@^1.4.1, chokidar@^1.4.3, chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-cipher-base@^1.0.0, cipher-base@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
+cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
   dependencies:
     inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 clang-format@^1.0.46:
-  version "1.0.50"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.0.50.tgz#b40926fd5c8573f7d37ed074a32da9a370dbdbcf"
+  version "1.0.53"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.0.53.tgz#ff3668c40ecceeeeaa3e977b61d50106d0b3fd46"
   dependencies:
     async "^1.5.2"
     glob "^7.0.0"
     resolve "^1.1.6"
 
 clap@^1.0.9:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
   dependencies:
     chalk "^1.1.3"
 
-clean-css@4.0.x:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.0.12.tgz#a02e61707f1840bd3338f54dbc9acbda4e772fa3"
+clean-css@4.1.x:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.7.tgz#b9aea4f85679889cf3eae8b40349ec4ebdfdd032"
   dependencies:
     source-map "0.5.x"
 
@@ -910,14 +964,13 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
-clone-deep@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
+clone-deep@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.3.0.tgz#348c61ae9cdbe0edfe053d91ff4cc521d790ede8"
   dependencies:
-    for-own "^0.1.3"
+    for-own "^1.0.0"
     is-plain-object "^2.0.1"
-    kind-of "^3.0.2"
-    lazy-cache "^1.0.3"
+    kind-of "^3.2.2"
     shallow-clone "^0.1.2"
 
 clone-stats@^0.0.1:
@@ -949,8 +1002,8 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 coa@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.1.tgz#7f959346cfc8719e3f7233cd6852854a7c67d8a3"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
   dependencies:
     q "^1.1.2"
 
@@ -959,8 +1012,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 codecov@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.1.0.tgz#25f48f9e9aa7473b61c5a9a934d595420a71cade"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.2.0.tgz#2d06817ceb8891eca6368836d4fb6bf6cc04ffd1"
   dependencies:
     argv "0.0.2"
     request "2.79.0"
@@ -977,15 +1030,15 @@ codelyzer@~2.0.0:
     source-map "^0.5.6"
     sprintf-js "^1.0.3"
 
-color-convert@^1.3.0:
+color-convert@^1.0.0, color-convert@^1.3.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
     color-name "^1.1.1"
 
 color-name@^1.0.0, color-name@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 color-string@^0.3.0:
   version "0.3.0"
@@ -1025,15 +1078,19 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.x, commander@^2.9.0:
+commander@2.9.x, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 commandpost@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/commandpost/-/commandpost-1.0.1.tgz#7d7e3e69ae8fe7d6949341e91596ede9b2d631fd"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/commandpost/-/commandpost-1.1.0.tgz#3524ac70002f3e8a5efcc2850294517b0bd60cd1"
 
 common-tags@^1.3.1:
   version "1.4.0"
@@ -1057,7 +1114,7 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
-compress-commons@^1.1.0:
+compress-commons@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-1.2.0.tgz#58587092ef20d37cb58baf000112c9278ff73b9f"
   dependencies:
@@ -1066,44 +1123,45 @@ compress-commons@^1.1.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
-compressible@~2.0.8:
+compressible@~2.0.10:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.10.tgz#feda1c7f7617912732b29bf8cf26252a20b9eecd"
   dependencies:
     mime-db ">= 1.27.0 < 2"
 
 compression@^1.5.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/compression/-/compression-1.6.2.tgz#cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.0.tgz#030c9f198f1643a057d776a738e922da4373012d"
   dependencies:
     accepts "~1.3.3"
-    bytes "2.3.0"
-    compressible "~2.0.8"
-    debug "~2.2.0"
+    bytes "2.5.0"
+    compressible "~2.0.10"
+    debug "2.6.8"
     on-headers "~1.0.1"
-    vary "~1.1.0"
+    safe-buffer "5.1.1"
+    vary "~1.1.1"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 concat-stream@^1.4.7:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 configstore@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.0.0.tgz#e1b8669c1803ccc50b545e92f8e6e79aa80e0196"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.0.tgz#45df907073e26dfa1cf4b2d52f5b60545eaa11d1"
   dependencies:
     dot-prop "^4.1.0"
     graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
+    make-dir "^1.0.0"
     unique-string "^1.0.0"
-    write-file-atomic "^1.1.2"
+    write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
 connect-history-api-fallback@^1.3.0:
@@ -1111,11 +1169,11 @@ connect-history-api-fallback@^1.3.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz#e51d17f8f0ef0db90a64fdb47de3051556e9f169"
 
 connect@^3.6.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.1.tgz#b7760693a74f0454face1d9378edb3f885b43227"
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.2.tgz#694e8d20681bfe490282c8ab886be98f09f42fe7"
   dependencies:
-    debug "2.6.3"
-    finalhandler "1.0.1"
+    debug "2.6.7"
+    finalhandler "1.0.3"
     parseurl "~1.3.1"
     utils-merge "1.0.0"
 
@@ -1157,6 +1215,12 @@ core-js@^2.2.0, core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
+core-object@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/core-object/-/core-object-3.1.3.tgz#df399b3311bdb0c909e8aae8929fc3c1c4b25880"
+  dependencies:
+    chalk "^1.1.3"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1197,28 +1261,25 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.2.tgz#51210062d7bb7479f6c65bb41a92208b1d61abad"
+create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.3.tgz#606042ac8b9262750f483caddab0f5819172d8fd"
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
-    ripemd160 "^1.0.0"
-    sha.js "^2.3.6"
+    ripemd160 "^2.0.0"
+    sha.js "^2.4.0"
 
-create-hmac@^1.1.0, create-hmac@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.4.tgz#d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170"
+create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
   dependencies:
+    cipher-base "^1.0.3"
     create-hash "^1.1.0"
     inherits "^2.0.1"
-
-cross-spawn-async@^2.1.1:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
-  dependencies:
-    lru-cache "^4.0.0"
-    which "^1.2.8"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 cross-spawn@^3.0.0:
   version "3.0.1"
@@ -1242,8 +1303,8 @@ cryptiles@2.x.x:
     boom "2.x.x"
 
 crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.11.0.tgz#3652a0906ab9b2a7e0c3ce66a408e957a2485522"
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.11.1.tgz#948945efc6757a400d6e5e5af47194d10064279f"
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -1264,13 +1325,14 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader@^0.27.3:
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.27.3.tgz#69ab6f47b69bfb1b5acee61bac2aab14302ff0dc"
+css-loader@^0.28.1:
+  version "0.28.4"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.4.tgz#6cf3579192ce355e8b38d5f42dd7a1f2ec898d0f"
   dependencies:
     babel-code-frame "^6.11.0"
     css-selector-tokenizer "^0.7.0"
     cssnano ">=2.6.1 <4"
+    icss-utils "^2.1.0"
     loader-utils "^1.0.2"
     lodash.camelcase "^4.3.0"
     object-assign "^4.0.1"
@@ -1279,6 +1341,7 @@ css-loader@^0.27.3:
     postcss-modules-local-by-default "^1.0.1"
     postcss-modules-scope "^1.0.0"
     postcss-modules-values "^1.1.0"
+    postcss-value-parser "^3.3.0"
     source-list-map "^0.1.7"
 
 css-parse@1.7.x:
@@ -1293,14 +1356,6 @@ css-select@^1.1.0:
     css-what "2.1"
     domutils "1.5.1"
     nth-check "~1.0.1"
-
-css-selector-tokenizer@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz#6445f582c7930d241dcc5007a43d6fcb8f073152"
-  dependencies:
-    cssesc "^0.1.0"
-    fastparse "^1.1.1"
-    regexpu-core "^1.0.0"
 
 css-selector-tokenizer@^0.7.0:
   version "0.7.0"
@@ -1399,13 +1454,13 @@ dateformat@^1.0.11, dateformat@^1.0.6:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@*, debug@2, debug@^2.1.3, debug@^2.2.0:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
+debug@*, debug@2, debug@2.6.8, debug@^2.2.0, debug@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
-    ms "0.7.3"
+    ms "2.0.0"
 
-debug@2.2.0, debug@~2.2.0:
+debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1417,17 +1472,11 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+debug@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
   dependencies:
-    ms "0.7.2"
-
-debug@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
-  dependencies:
-    ms "0.7.2"
+    ms "2.0.0"
 
 debug@^0.7.2:
   version "0.7.4"
@@ -1438,8 +1487,8 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
 deep-extend@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1494,13 +1543,17 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-node@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
+
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
 
 diff@^3.0.1, diff@^3.1.0, diff@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1607,8 +1660,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.9.tgz#db1cba2a26aebcca2f7f5b8b034554468609157d"
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -1686,8 +1739,8 @@ engine.io@1.8.3:
     ws "1.1.2"
 
 enhanced-resolve@^3.0.0, enhanced-resolve@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz#950964ecc7f0332a42321b673b38dc8ff15535b3"
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
@@ -1719,8 +1772,8 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es6-promise@^4.0.5:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.0.tgz#dda03ca8f9f89bc597e689842929de7ba8cebdf0"
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -1744,6 +1797,10 @@ escodegen@1.8.x:
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
 estraverse@^1.9.1:
   version "1.9.3"
@@ -1777,15 +1834,16 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
-execa@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   dependencies:
-    cross-spawn-async "^2.1.1"
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
     is-stream "^1.1.0"
-    npm-run-path "^1.0.0"
-    object-assign "^4.0.1"
-    path-key "^1.0.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
 exit@^0.1.2:
@@ -1827,8 +1885,8 @@ exports-loader@^0.6.3:
     source-map "0.5.x"
 
 express@^4.13.3:
-  version "4.15.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.15.2.tgz#af107fc148504457f2dca9a6f2571d7129b97b35"
+  version "4.15.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
     accepts "~1.3.3"
     array-flatten "1.1.1"
@@ -1836,37 +1894,39 @@ express@^4.13.3:
     content-type "~1.0.2"
     cookie "0.3.1"
     cookie-signature "1.0.6"
-    debug "2.6.1"
+    debug "2.6.7"
     depd "~1.1.0"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     etag "~1.8.0"
-    finalhandler "~1.0.0"
+    finalhandler "~1.0.3"
     fresh "0.5.0"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
     on-finished "~2.3.0"
     parseurl "~1.3.1"
     path-to-regexp "0.1.7"
-    proxy-addr "~1.1.3"
+    proxy-addr "~1.1.4"
     qs "6.4.0"
     range-parser "~1.2.0"
-    send "0.15.1"
-    serve-static "1.12.1"
+    send "0.15.3"
+    serve-static "1.12.3"
     setprototypeof "1.0.3"
     statuses "~1.3.1"
-    type-is "~1.6.14"
+    type-is "~1.6.15"
     utils-merge "1.0.0"
-    vary "~1.1.0"
+    vary "~1.1.1"
 
 extend@3, extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.1.tgz#4c597c6c88fa6410e41dbbaa7b1be2336aa31095"
+external-editor@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
   dependencies:
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
     tmp "^0.0.31"
 
 extglob@^0.3.1:
@@ -1876,13 +1936,13 @@ extglob@^0.3.1:
     is-extglob "^1.0.0"
 
 extract-text-webpack-plugin@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz#69315b885f876dbf96d3819f6a9f1cca7aebf159"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz#756ef4efa8155c3681833fbc34da53b941746d6c"
   dependencies:
-    ajv "^4.11.2"
     async "^2.1.2"
     loader-utils "^1.0.2"
-    webpack-sources "^0.1.0"
+    schema-utils "^0.3.0"
+    webpack-sources "^1.0.1"
 
 extsprintf@1.0.2:
   version "1.0.2"
@@ -1894,6 +1954,10 @@ fancy-log@^1.1.0:
   dependencies:
     chalk "^1.1.1"
     time-stamp "^1.0.0"
+
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1941,11 +2005,11 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-finalhandler@1.0.1, finalhandler@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.1.tgz#bcd15d1689c0e5ed729b6f7f541a6df984117db8"
+finalhandler@1.0.3, finalhandler@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
   dependencies:
-    debug "2.6.3"
+    debug "2.6.7"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
@@ -1978,9 +2042,15 @@ for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
-for-own@^0.1.3, for-own@^0.1.4:
+for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
 
@@ -2019,23 +2089,24 @@ fs-extra@^0.23.1:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.1.tgz#f19fd28f43eeaf761680e519a203c4d0b3d31aff"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.29"
+    node-pre-gyp "^0.6.36"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -2147,13 +2218,13 @@ glob@^5.0.14, glob@^5.0.15, glob@~5.0.0:
     path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2167,8 +2238,8 @@ glob@~4.5.x:
     once "^1.3.0"
 
 globals@^9.0.0:
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2182,11 +2253,11 @@ globby@^5.0.0:
     pinkie-promise "^2.0.0"
 
 globule@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.1.0.tgz#c49352e4dc183d85893ee825385eb994bb6df45f"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09"
   dependencies:
     glob "~7.1.1"
-    lodash "~4.16.4"
+    lodash "~4.17.4"
     minimatch "~3.0.2"
 
 glogg@^1.0.0:
@@ -2260,7 +2331,7 @@ hammerjs@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
 
-handle-thing@^1.2.4:
+handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
 
@@ -2273,8 +2344,8 @@ handlebars@^1.3.0:
     uglify-js "~2.3"
 
 handlebars@^4.0.1:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.8.tgz#22b875cd3f0e6cbea30314f144e82bc7a72ff420"
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -2322,6 +2393,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -2338,11 +2413,18 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.0.3.tgz#1332ff00156c0a0ffdd8236013d07b77a0451573"
+hash-base@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
   dependencies:
     inherits "^2.0.1"
+
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.0"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -2357,6 +2439,19 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+heimdalljs-logger@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz#d76ada4e45b7bb6f786fc9c010a68eb2e2faf176"
+  dependencies:
+    debug "^2.2.0"
+    heimdalljs "^0.2.0"
+
+heimdalljs@^0.2.0, heimdalljs@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
+  dependencies:
+    rsvp "~3.2.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2370,8 +2465,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hosted-git-info@^2.1.4:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -2391,21 +2486,21 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.4.4.tgz#616fe3e3ef16da02b393d9a6099eeff468a35df0"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.2.tgz#d73bc3ff448942408818ce609bf3fb0ea7ef4eb7"
   dependencies:
     camel-case "3.0.x"
-    clean-css "4.0.x"
+    clean-css "4.1.x"
     commander "2.9.x"
     he "1.1.x"
     ncname "1.0.x"
     param-case "2.1.x"
     relateurl "0.2.x"
-    uglify-js "~2.8.22"
+    uglify-js "3.0.x"
 
 html-webpack-plugin@^2.19.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz#2e7863b57e5fd48fe263303e2ffc934c3064d009"
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz#e987f421853d3b6938c8c4c8171842e5fd17af23"
   dependencies:
     bluebird "^3.4.7"
     html-minifier "^3.2.3"
@@ -2423,17 +2518,9 @@ htmlparser2@~3.3.0:
     domutils "1.1"
     readable-stream "1.0"
 
-http-deceiver@^1.2.4:
+http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
-
-http-errors@~1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.5.1.tgz#788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
-  dependencies:
-    inherits "2.0.3"
-    setprototypeof "1.0.2"
-    statuses ">= 1.3.1 < 2"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -2484,23 +2571,37 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-icss-replace-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz#cb0b6054eb3af6edc9ab1d62d01933e2d4c8bfa5"
+iconv-lite@^0.4.17:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+icss-replace-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
+
+icss-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
+  dependencies:
+    postcss "^6.0.1"
 
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 image-size@~0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.1.tgz#28eea8548a4b1443480ddddc1e083ae54652439f"
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
 img-stats@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/img-stats/-/img-stats-0.5.2.tgz#c203496c42f2d9eb2e5ab8232fa756bab32c9e2b"
   dependencies:
     xmldom "^0.1.19"
+
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2535,7 +2636,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2548,21 +2649,22 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
 inquirer@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.0.tgz#45b44c2160c729d7578c54060b3eed94487bb42b"
   dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
+    ansi-escapes "^2.0.0"
+    chalk "^2.0.0"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^2.0.1"
+    external-editor "^2.0.4"
     figures "^2.0.0"
     lodash "^4.3.0"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^2.0.0"
-    strip-ansi "^3.0.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 interpret@^1.0.0:
@@ -2612,8 +2714,8 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
@@ -2678,9 +2780,15 @@ is-number@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-0.1.1.tgz#69a7af116963d47206ec9bd9b48a14216f1e3806"
 
-is-number@^2.0.2, is-number@^2.1.0:
+is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
 
@@ -2709,10 +2817,10 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-plain-object@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.1.tgz#4d7ca539bc9db9b737b8acb612f2318ef92f294f"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
-    isobject "^1.0.0"
+    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -2772,15 +2880,15 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isobject@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2795,20 +2903,20 @@ istanbul-instrumenter-loader@^2.0.0:
     loader-utils "^0.2.16"
     object-assign "^4.1.0"
 
-istanbul-lib-coverage@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#caca19decaef3525b5d6331d701f3f3b7ad48528"
+istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
 istanbul-lib-instrument@^1.1.3:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz#169e31bc62c778851a99439dd99c3cc12184d360"
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz#e9fd920e4767f3d19edc765e2d6b3f5ccbd0eea8"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.1.0"
+    babylon "^6.17.4"
+    istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
 istanbul@0.4.5, istanbul@^0.4.0:
@@ -2831,8 +2939,8 @@ istanbul@0.4.5, istanbul@^0.4.0:
     wordwrap "^1.0.0"
 
 jasmine-core@^2.5.2, jasmine-core@~2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.6.1.tgz#66a61cddb699958e3613edef346c996f6311fc3b"
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.6.4.tgz#dec926cd0a9fa287fb6db5c755fa487e74cecac5"
 
 jasmine-spec-reporter@~3.2.0:
   version "3.2.0"
@@ -2848,25 +2956,26 @@ jasmine@^2.5.3:
     glob "^7.0.6"
     jasmine-core "~2.6.0"
 
-jasminewd2@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.0.0.tgz#10aacd2c588c1ceb6a0b849f1a7f3f959f777c91"
-
-jodid25519@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
-  dependencies:
-    jsbn "~0.1.0"
+jasminewd2@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.1.0.tgz#da595275d1ae631de736ac0a7c7d85c9f73ef652"
 
 js-base64@^2.1.5, js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
 js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x, js-yaml@^3.4.3, js-yaml@~3.7.0:
+js-yaml@3.x, js-yaml@^3.4.3:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -2876,6 +2985,10 @@ js-yaml@3.x, js-yaml@^3.4.3, js-yaml@~3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jschardet@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -2888,6 +3001,10 @@ jsesc@~0.5.0:
 json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -2907,13 +3024,19 @@ json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -2935,8 +3058,8 @@ jsprim@^1.2.2:
     verror "1.3.6"
 
 karma-chrome-launcher@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz#216879c68ac04d8d5140e99619ba04b59afd46cf"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
   dependencies:
     fs-access "^1.0.0"
     which "^1.2.1"
@@ -2984,15 +3107,9 @@ karma-sauce-launcher@^1.1.0:
     saucelabs "^1.3.0"
     wd "^1.0.0"
 
-karma-sourcemap-loader@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
-  dependencies:
-    graceful-fs "^4.1.2"
-
 karma-typescript@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/karma-typescript/-/karma-typescript-3.0.2.tgz#992a62bec1cd48131dbe022fd01ea19a0338b090"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/karma-typescript/-/karma-typescript-3.0.4.tgz#9cdeeeddd1671693440c34ec62aba2d6ff9e4b05"
   dependencies:
     acorn "^4.0.4"
     amdefine "1.0.0"
@@ -3046,16 +3163,6 @@ karma-verbose-reporter@0.0.5:
   dependencies:
     colors ">=1.0"
 
-karma-webpack@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-2.0.3.tgz#39cebf5ca2580139b27f9ae69b78816b9c82fae6"
-  dependencies:
-    async "~0.9.0"
-    loader-utils "^0.2.5"
-    lodash "^3.8.0"
-    source-map "^0.1.41"
-    webpack-dev-middleware "^1.0.11"
-
 karma@^1.5.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/karma/-/karma-1.7.0.tgz#6f7a1a406446fa2e187ec95398698f4cee476269"
@@ -3094,9 +3201,15 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.0.tgz#b58abe4d5c044ad33726a8c1525b48cf891bff07"
+kind-of@^3.0.2, kind-of@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
 
@@ -3114,10 +3227,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lazy-req@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-2.0.0.tgz#c9450a363ecdda2e6f0c70132ad4f37f8f06f2b4"
-
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -3131,8 +3240,8 @@ lcid@^1.0.0:
     invert-kv "^1.0.0"
 
 less-loader@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-4.0.3.tgz#d1e6462ca2f090c11248455e14b8dda4616d0521"
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-4.0.5.tgz#ae155a7406cac6acd293d785587fcff0f478c4dd"
   dependencies:
     clone "^2.1.1"
     loader-utils "^1.1.0"
@@ -3158,6 +3267,12 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+license-webpack-plugin@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/license-webpack-plugin/-/license-webpack-plugin-0.4.3.tgz#f9d88d4ebc04407a0061e8ccac26571f88e51a16"
+  dependencies:
+    object-assign "^4.1.0"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3172,7 +3287,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@~0.2.2:
+loader-utils@^0.2.16, loader-utils@~0.2.2:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -3308,17 +3423,13 @@ lodash@4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.2.tgz#3e626db827048a699281a8a125226326cfc0e652"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@~4.13.x:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
-
-lodash@~4.16.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 log4js@^0.6.31:
   version "0.6.38"
@@ -3370,26 +3481,32 @@ lru-cache@^3.2.0:
   dependencies:
     pseudomap "^1.0.1"
 
-lru-cache@^4.0.0, lru-cache@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
 magic-string@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.0.tgz#198948217254e3e0b93080e01146b7c73b2a06b2"
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.1.tgz#14d768013caf2ec8fdea16a49af82fc377e75201"
   dependencies:
     vlq "^0.2.1"
 
+make-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
+  dependencies:
+    pify "^2.3.0"
+
 make-error@^1.1.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.2.3.tgz#6c4402df732e0977ac6faf754a5074b3d2b1d19d"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -3409,7 +3526,7 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:
@@ -3474,9 +3591,13 @@ mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-mime@1.3.4, mime@1.3.x, mime@^1.2.11, mime@^1.3.4:
+mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mime@1.3.x, mime@^1.2.11, mime@^1.3.4:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -3490,7 +3611,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3535,9 +3656,9 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 multipipe@^0.1.2:
   version "0.1.2"
@@ -3570,8 +3691,8 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-gyp@^3.3.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.1.tgz#19561067ff185464aded478212681f47fd578cbc"
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
   dependencies:
     fstream "^1.0.0"
     glob "^7.0.3"
@@ -3619,9 +3740,9 @@ node-modules-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
 
-node-pre-gyp@^0.6.29:
-  version "0.6.34"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz#94ad1c798a11d7fc67381b50d47f8cc18d9799f7"
+node-pre-gyp@^0.6.36:
+  version "0.6.36"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -3634,8 +3755,8 @@ node-pre-gyp@^0.6.29:
     tar-pack "^3.4.0"
 
 node-sass@^4.3.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -3670,8 +3791,8 @@ nopt@^4.0.1:
     osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -3697,15 +3818,15 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-run-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
-    path-key "^1.0.0"
+    path-key "^2.0.0"
 
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -3757,7 +3878,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-obuf@^1.0.0, obuf@^1.1.0:
+obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
 
@@ -3857,6 +3978,10 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
 package-json@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
@@ -3945,9 +4070,9 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -3966,10 +4091,14 @@ path-type@^1.0.0:
     pinkie-promise "^2.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.9.tgz#f2c4b25a600058b3c3773c086c37dbbee1ffe693"
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
   dependencies:
-    create-hmac "^1.1.2"
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -3978,6 +4107,10 @@ performance-now@^0.2.0:
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -4152,31 +4285,31 @@ postcss-minify-selectors@^2.0.4:
     postcss-selector-parser "^2.0.0"
 
 postcss-modules-extract-imports@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz#8fb3fef9a6dd0420d3f6d4353cf1ff73f2b2a341"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz#66140ecece38ef06bf0d3e355d69bf59d141ea85"
   dependencies:
-    postcss "^5.0.4"
+    postcss "^6.0.1"
 
 postcss-modules-local-by-default@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz#29a10673fa37d19251265ca2ba3150d9040eb4ce"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
   dependencies:
-    css-selector-tokenizer "^0.6.0"
-    postcss "^5.0.4"
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
 
 postcss-modules-scope@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz#ff977395e5e06202d7362290b88b1e8cd049de29"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
   dependencies:
-    css-selector-tokenizer "^0.6.0"
-    postcss "^5.0.4"
+    css-selector-tokenizer "^0.7.0"
+    postcss "^6.0.1"
 
 postcss-modules-values@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz#f0e7d476fe1ed88c5e4c7f97533a3e772ad94ca1"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
   dependencies:
-    icss-replace-symbols "^1.0.2"
-    postcss "^5.0.14"
+    icss-replace-symbols "^1.1.0"
+    postcss "^6.0.1"
 
 postcss-normalize-charset@^1.1.0:
   version "1.1.1"
@@ -4279,6 +4412,14 @@ postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^6.0.1:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.7.tgz#6a097477c46d13d0560a817d69abc0bae549d0a0"
+  dependencies:
+    chalk "^2.0.1"
+    source-map "^0.5.6"
+    supports-color "^4.2.0"
+
 pre-commit@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
@@ -4300,8 +4441,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 pretty-error@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.0.tgz#87f4e9d706a24c87d6cbee9fabec001fcf8c75d8"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
@@ -4315,14 +4456,14 @@ process@^0.11.0, process@~0.11.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
 promise@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
 protractor@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/protractor/-/protractor-5.1.1.tgz#10c4e336571b28875b8acc3ae3e4e1e40ef7e986"
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/protractor/-/protractor-5.1.2.tgz#9b221741709a4c62d5cd53c6aadd54a71137e95f"
   dependencies:
     "@types/node" "^6.0.46"
     "@types/q" "^0.0.32"
@@ -4331,16 +4472,16 @@ protractor@~5.1.0:
     chalk "^1.1.3"
     glob "^7.0.3"
     jasmine "^2.5.3"
-    jasminewd2 "^2.0.0"
+    jasminewd2 "^2.1.0"
     optimist "~0.6.0"
     q "1.4.1"
     saucelabs "~1.3.0"
     selenium-webdriver "3.0.1"
     source-map-support "~0.4.0"
     webdriver-js-extender "^1.0.0"
-    webdriver-manager "^12.0.1"
+    webdriver-manager "^12.0.6"
 
-proxy-addr@~1.1.3:
+proxy-addr@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
   dependencies:
@@ -4351,7 +4492,7 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -4413,15 +4554,17 @@ querystringify@~1.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
 randomatic@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
   dependencies:
-    is-number "^2.0.2"
-    kind-of "^3.0.2"
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 randombytes@^2.0.0, randombytes@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
+  dependencies:
+    safe-buffer "^5.1.0"
 
 range-parser@^1.0.3, range-parser@^1.2.0, range-parser@~1.2.0:
   version "1.2.0"
@@ -4481,16 +4624,16 @@ readable-stream@^1.1.7, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
-    buffer-shims "~1.0.0"
     core-util-is "~1.0.0"
-    inherits "~2.0.1"
+    inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    string_decoder "~1.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readable-stream@~2.0.0:
@@ -4599,8 +4742,8 @@ remap-istanbul@^0.8.4:
     through2 "2.0.1"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
 
 renderkid@^2.0.1:
   version "2.0.1"
@@ -4729,7 +4872,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -4745,9 +4888,12 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-ripemd160@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
+  dependencies:
+    hash-base "^2.0.0"
+    inherits "^2.0.1"
 
 rollup-plugin-node-resolve@^2.0.0:
   version "2.1.1"
@@ -4764,8 +4910,12 @@ rollup@^0.41.4:
     source-map-support "^0.4.0"
 
 rsvp@^3.0.17:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
+rsvp@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -4773,38 +4923,44 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 rxjs@^5.0.1, rxjs@^5.1.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.1.tgz#9ecc9e722247e4f4490d30a878577a3740fd0cb7"
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 sass-graph@^2.1.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.2.tgz#f4d6c95b546ea2a09d14176d0fc1a07ee2b48354"
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
   dependencies:
     glob "^7.0.0"
     lodash "^4.0.0"
-    scss-tokenizer "^0.2.1"
-    yargs "^6.6.0"
+    scss-tokenizer "^0.2.3"
+    yargs "^7.0.0"
 
 sass-loader@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.3.tgz#33983b1f90d27ddab0e57d0dac403dce9bc7ecfd"
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.6.tgz#e9d5e6c1f155faa32a4b26d7a9b7107c225e40f9"
   dependencies:
     async "^2.1.5"
-    clone-deep "^0.2.4"
+    clone-deep "^0.3.0"
     loader-utils "^1.0.1"
     lodash.tail "^4.1.1"
-    pify "^2.3.0"
+    pify "^3.0.0"
 
 sauce-connect-launcher@^0.17.0:
   version "0.17.0"
@@ -4831,8 +4987,14 @@ sax@0.6.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.6.1.tgz#563b19c7c1de892e09bfc4f2fc30e3c27f0952b9"
 
 sax@>=0.6.0, sax@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schema-utils@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
+  dependencies:
+    ajv "^5.0.0"
 
 script-loader@^0.7.0:
   version "0.7.0"
@@ -4840,9 +5002,9 @@ script-loader@^0.7.0:
   dependencies:
     raw-loader "~0.5.1"
 
-scss-tokenizer@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.1.tgz#07c0cc577bb7ab4d08fd900185adbf4bc844141d"
+scss-tokenizer@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
@@ -4894,11 +5056,11 @@ semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
-send@0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.15.1.tgz#8a02354c26e6f5cca700065f5f0cdeba90ec7b5f"
+send@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
   dependencies:
-    debug "2.6.1"
+    debug "2.6.7"
     depd "~1.1.0"
     destroy "~1.0.4"
     encodeurl "~1.0.1"
@@ -4907,31 +5069,31 @@ send@0.15.1:
     fresh "0.5.0"
     http-errors "~1.6.1"
     mime "1.3.4"
-    ms "0.7.2"
+    ms "2.0.0"
     on-finished "~2.3.0"
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
 serve-index@^1.7.2:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.8.0.tgz#7c5d96c13fb131101f93c1c5774f8516a1e78d3b"
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.0.tgz#d2b280fc560d616ee81b48bf0fa82abed2485ce7"
   dependencies:
     accepts "~1.3.3"
-    batch "0.5.3"
-    debug "~2.2.0"
+    batch "0.6.1"
+    debug "2.6.8"
     escape-html "~1.0.3"
-    http-errors "~1.5.0"
-    mime-types "~2.1.11"
+    http-errors "~1.6.1"
+    mime-types "~2.1.15"
     parseurl "~1.3.1"
 
-serve-static@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.1.tgz#7443a965e3ced647aceb5639fa06bf4d1bbe0039"
+serve-static@1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
   dependencies:
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     parseurl "~1.3.1"
-    send "0.15.1"
+    send "0.15.3"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -4945,15 +5107,11 @@ setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
-setprototypeof@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.2.tgz#81a552141ec104b88e89ce383103ad5c66564d08"
-
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
-sha.js@^2.3.6:
+sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
@@ -5070,13 +5228,21 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^0.1.7, source-list-map@~0.1.7:
+source-list-map@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
-source-map-loader@^0.1.5:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.1.6.tgz#c09903da6d73b9e53b7ed8ee5245597051e98e91"
+source-list-map@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
+
+source-list-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-map-loader@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.1.tgz#48126be9230bd47fad05e46a8c3c2e3d2dabe507"
   dependencies:
     async "^0.9.0"
     loader-utils "~0.2.2"
@@ -5088,7 +5254,7 @@ source-map-support@^0.4.0, source-map-support@^0.4.2, source-map-support@~0.4.0:
   dependencies:
     source-map "^0.5.6"
 
-source-map@0.1.x, source-map@^0.1.41, source-map@~0.1.33, source-map@~0.1.7:
+source-map@0.1.x, source-map@~0.1.33, source-map@~0.1.7:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -5135,37 +5301,40 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-spdy-transport@^2.0.15:
-  version "2.0.18"
-  resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-2.0.18.tgz#43fc9c56be2cccc12bb3e2754aa971154e836ea6"
+spdy-transport@^2.0.18:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-2.0.20.tgz#735e72054c486b2354fe89e702256004a39ace4d"
   dependencies:
-    debug "^2.2.0"
+    debug "^2.6.8"
+    detect-node "^2.0.3"
     hpack.js "^2.1.6"
-    obuf "^1.1.0"
-    readable-stream "^2.0.1"
-    wbuf "^1.4.0"
+    obuf "^1.1.1"
+    readable-stream "^2.2.9"
+    safe-buffer "^5.0.1"
+    wbuf "^1.7.2"
 
 spdy@^3.4.1:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.4.tgz#e0406407ca90ff01b553eb013505442649f5a819"
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.7.tgz#42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc"
   dependencies:
-    debug "^2.2.0"
-    handle-thing "^1.2.4"
-    http-deceiver "^1.2.4"
+    debug "^2.6.8"
+    handle-thing "^1.2.5"
+    http-deceiver "^1.2.7"
+    safe-buffer "^5.0.1"
     select-hose "^2.0.0"
-    spdy-transport "^2.0.15"
+    spdy-transport "^2.0.18"
 
 sprintf-js@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.0.tgz#cffcaf702daf65ea39bb4e0fa2b299cec1a1be46"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -5174,7 +5343,6 @@ sshpk@^1.7.0:
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
-    jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
@@ -5196,8 +5364,8 @@ stream-browserify@^2.0.0, stream-browserify@^2.0.1:
     readable-stream "^2.0.2"
 
 stream-http@^2.0.0, stream-http@^2.3.1:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.0.tgz#cec1f4e3b494bc4a81b451808970f8b20b4ed5f6"
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -5226,22 +5394,22 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+string-width@^2.0.0, string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^4.0.0"
 
 string_decoder@^0.10.25, string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
-    buffer-shims "~1.0.0"
+    safe-buffer "~5.1.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -5252,6 +5420,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -5308,6 +5482,12 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0, supports-color@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  dependencies:
+    has-flag "^2.0.0"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -5342,8 +5522,8 @@ tar-pack@^3.4.0:
     uid-number "^0.0.6"
 
 tar-stream@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.4.tgz#36549cf04ed1aee9b2a30c0143252238daf94016"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
@@ -5365,11 +5545,11 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-term-size@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-0.1.1.tgz#87360b96396cab5760963714cda0d0cbeecad9ca"
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
   dependencies:
-    execa "^0.4.0"
+    execa "^0.7.0"
 
 through2@2.0.1, through2@^2.0.0, through2@^2.0.1:
   version "2.0.1"
@@ -5383,8 +5563,8 @@ through@X.X.X, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 time-stamp@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.0.1.tgz#9f4bd23559c9365966f3302dbba2b07c6b99b151"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
 
 timed-out@^4.0.0:
   version "4.0.1"
@@ -5489,9 +5669,9 @@ tsickle@^0.21.0:
     source-map "^0.5.6"
     source-map-support "^0.4.2"
 
-tslib@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.0.tgz#6e8366695f72961252b35167b0dd4fbeeafba491"
+tslib@^1.6.0, tslib@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
 tslint-microsoft-contrib@^4.0.0:
   version "4.0.1"
@@ -5512,8 +5692,8 @@ tslint@^4.4.2:
     update-notifier "^2.0.0"
 
 tsutils@^1.1.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.8.0.tgz#bf8118ed8e80cd5c9fc7d75728c7963d44ed2f52"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 tty-browserify@0.0.0, tty-browserify@~0.0.0:
   version "0.0.0"
@@ -5539,14 +5719,14 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.14:
+type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typedarray@~0.0.5:
+typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
@@ -5558,17 +5738,24 @@ typescript-formatter@^4.1.1:
     editorconfig "^0.13.2"
     glob-expand "^0.2.1"
 
-"typescript@>=2.0.0 <2.3.0":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
+"typescript@>=2.0.0 <2.4.0":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
 
 typescript@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
-uglify-js@^2.6, uglify-js@^2.7.5, uglify-js@~2.8.22:
-  version "2.8.23"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.23.tgz#8230dd9783371232d62a7821e2cf9a817270a8a0"
+uglify-js@3.0.x:
+  version "3.0.25"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.25.tgz#3dc190b0ee437497e449bc6f785665b06afbe052"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
+
+uglify-js@^2.6, uglify-js@^2.8.5:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -5622,6 +5809,10 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -5631,15 +5822,15 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 update-notifier@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.1.0.tgz#ec0c1e53536b76647a24b77cb83966d9315123d9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.2.0.tgz#1b5837cf90c0736d88627732b661c138f86de72f"
   dependencies:
     boxen "^1.0.0"
     chalk "^1.0.0"
     configstore "^3.0.0"
+    import-lazy "^2.1.0"
     is-npm "^1.0.0"
     latest-version "^3.0.0"
-    lazy-req "^2.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
@@ -5648,8 +5839,8 @@ upper-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 url-loader@^0.5.7:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.5.8.tgz#b9183b1801e0f847718673673040bc9dc1c715c5"
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.5.9.tgz#cc8fea82c7b906e7777019250869e569e995c295"
   dependencies:
     loader-utils "^1.0.2"
     mime "1.3.x"
@@ -5690,8 +5881,8 @@ user-home@^1.1.1:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
 useragent@^2.1.12:
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.1.13.tgz#bba43e8aa24d5ceb83c2937473e102e21df74c10"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.2.1.tgz#cf593ef4f2d175875e8bb658ea92e18a4fd06d8e"
   dependencies:
     lru-cache "2.2.x"
     tmp "0.0.x"
@@ -5723,8 +5914,8 @@ uuid@^2.0.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 v8flags@^2.0.11:
   version "2.1.1"
@@ -5743,7 +5934,7 @@ vargs@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/vargs/-/vargs-0.1.0.tgz#6b6184da6520cc3204ce1b407cac26d92609ebff"
 
-vary@~1.1.0:
+vary@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
@@ -5772,14 +5963,13 @@ vinyl@^0.5.0:
     replace-ext "0.0.1"
 
 vinyl@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.0.2.tgz#0a3713d8d4e9221c58f10ca16c0116c9e25eda7c"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.1.0.tgz#021f9c2cf951d6b939943c89eb5ee5add4fd924c"
   dependencies:
-    clone "^1.0.0"
+    clone "^2.1.1"
     clone-buffer "^1.0.0"
     clone-stats "^1.0.0"
     cloneable-readable "^1.0.0"
-    is-stream "^1.1.0"
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
@@ -5798,8 +5988,8 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 walk-sync@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.1.tgz#558a16aeac8c0db59c028b73c66f397684ece465"
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
@@ -5808,23 +5998,23 @@ walkdir@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"
 
-watchpack@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.3.1.tgz#7d8693907b28ce6013e7f3610aa2a1acf07dad87"
+watchpack@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.4.0.tgz#4a1472bcbb952bd0a9bb4036801f954dfb39faac"
   dependencies:
     async "^2.1.2"
-    chokidar "^1.4.3"
+    chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
-wbuf@^1.1.0, wbuf@^1.4.0:
+wbuf@^1.1.0, wbuf@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.2.tgz#d697b99f1f59512df2751be42769c1580b5801fe"
   dependencies:
     minimalistic-assert "^1.0.0"
 
 wd@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/wd/-/wd-1.2.0.tgz#4112c4657eca5af593ebc060d54b80caeea04807"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/wd/-/wd-1.4.0.tgz#85958787abc32f048d4b3927b2ab3c5fc8c9c9fa"
   dependencies:
     archiver "1.3.0"
     async "2.0.1"
@@ -5846,9 +6036,9 @@ webdriver-js-extender@^1.0.0:
     "@types/selenium-webdriver" "^2.53.35"
     selenium-webdriver "^2.53.2"
 
-webdriver-manager@^12.0.1:
-  version "12.0.5"
-  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.0.5.tgz#364b8dd0a281720f4eddcc51ae0c3b442a067e3b"
+webdriver-manager@^12.0.6:
+  version "12.0.6"
+  resolved "https://registry.yarnpkg.com/webdriver-manager/-/webdriver-manager-12.0.6.tgz#3df1a481977010b4cbf8c9d85c7a577828c0e70b"
   dependencies:
     adm-zip "^0.4.7"
     chalk "^1.1.1"
@@ -5862,16 +6052,16 @@ webdriver-manager@^12.0.1:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
-webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz#2e252ce1dfb020dbda1ccb37df26f30ab014dbd1"
+webpack-dev-middleware@^1.10.2:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz#09691d0973a30ad1f82ac73a12e2087f0a4754f9"
   dependencies:
     memory-fs "~0.4.1"
     mime "^1.3.4"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@~2.4.2:
+webpack-dev-server@~2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz#31384ce81136be1080b4b4cde0eb9b90e54ee6cf"
   dependencies:
@@ -5899,18 +6089,25 @@ webpack-merge@^2.4.0:
   dependencies:
     lodash "^4.17.4"
 
-webpack-sources@^0.1.0, webpack-sources@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.5.tgz#aa1f3abf0f0d74db7111c40e500b84f966640750"
+webpack-sources@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.2.3.tgz#17c62bfaf13c707f9d02c479e0dcdde8380697fb"
   dependencies:
-    source-list-map "~0.1.7"
+    source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.2.1.tgz#7bb1d72ae2087dd1a4af526afec15eed17dda475"
+webpack-sources@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"
   dependencies:
-    acorn "^4.0.4"
+    source-list-map "^2.0.0"
+    source-map "~0.5.3"
+
+webpack@~2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.4.1.tgz#15a91dbe34966d8a4b99c7d656efd92a2e5a6f6a"
+  dependencies:
+    acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
     ajv "^4.7.0"
     ajv-keywords "^1.1.1"
@@ -5918,6 +6115,7 @@ webpack@~2.2.0:
     enhanced-resolve "^3.0.0"
     interpret "^1.0.0"
     json-loader "^0.5.4"
+    json5 "^0.5.1"
     loader-runner "^2.3.0"
     loader-utils "^0.2.16"
     memory-fs "~0.4.1"
@@ -5926,9 +6124,9 @@ webpack@~2.2.0:
     source-map "^0.5.3"
     supports-color "^3.1.0"
     tapable "~0.2.5"
-    uglify-js "^2.7.5"
-    watchpack "^1.2.0"
-    webpack-sources "^0.1.4"
+    uglify-js "^2.8.5"
+    watchpack "^1.3.1"
+    webpack-sources "^0.2.3"
     yargs "^6.0.0"
 
 websocket-driver@>=0.5.1:
@@ -5953,17 +6151,17 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@1.2.x, which@^1.1.1, which@^1.2.1, which@^1.2.8, which@^1.2.9:
+which@1, which@1.2.x, which@^1.1.1, which@^1.2.1, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
-    string-width "^1.0.1"
+    string-width "^1.0.2"
 
 widest-line@^1.0.0:
   version "1.0.0"
@@ -5998,17 +6196,24 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@^1.1.2:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+write-file-atomic@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.1.0.tgz#1769f4b551eedce419f0505deae2e26763542d37"
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@1.1.2, ws@^1.0.1:
+ws@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
+ws@^1.0.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
@@ -6061,7 +6266,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.0.0:
+yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
@@ -6071,7 +6276,13 @@ yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@^6.0.0, yargs@^6.6.0:
+yargs-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
+  dependencies:
+    camelcase "^3.0.0"
+
+yargs@^6.0.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:
@@ -6088,6 +6299,24 @@ yargs@^6.0.0, yargs@^6.6.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
+  dependencies:
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^5.0.0"
 
 yargs@~3.10.0:
   version "3.10.0"
@@ -6109,14 +6338,14 @@ yn@^1.2.0:
     object-assign "^4.1.1"
 
 zip-stream@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.1.1.tgz#5216b48bbb4d2651f64d5c6e6f09eb4a7399d557"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.2.0.tgz#a8bc45f4c1b49699c6b90198baacaacdbcd4ba04"
   dependencies:
     archiver-utils "^1.3.0"
-    compress-commons "^1.1.0"
+    compress-commons "^1.2.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
 
 zone.js@^0.8.11, zone.js@^0.8.4:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.11.tgz#742befb17fbc49a571712b8c7d87e58ca26fd886"
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.14.tgz#0c4db24b178232274ccb43f78c99db7f3642b6cf"


### PR DESCRIPTION
The main change after the upgrade is the usage of the native string enums. I updated some typings related to Message and Error to better accommodate this change.

Some new errors were also raised once I updated. The Credential and CredentialRequestOptions would conflict with the CredentialsManagement's own interfaces and I think the newly added weak detection checking would start throwing errors (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html). I added a OY prefix to such types.

The other substantial change is the refactoring of the api_test test cases as they were dependent to the order, and more targeted unit tests.