### PR TITLE
Implemented new errors design

### DIFF
--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
 import {RenderMode} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {PreloadRequest, PreloadRequestType} from '../protocol/preload_request';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, sha256, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
@@ -34,7 +34,7 @@ import {WrapBrowserRequest} from './wrap_browser_request';
 
 // re-export all the data types
 export * from '../protocol/data';
-export {OYInternalError, InternalErrorCode} from '../protocol/errors';
+export {OpenYoloInternalError, InternalErrorCode} from '../protocol/errors';
 
 const MOBILE_USER_AGENT_REGEX = /android|iphone|ipod|iemobile/i;
 
@@ -54,7 +54,7 @@ export interface OpenYoloApi {
    *     and resolves with false if none are available. The promise will not
    *     reject: if an error happen, it should resolve with false.
    */
-  hintsAvailable(options: OYCredentialHintOptions): Promise<boolean>;
+  hintsAvailable(options: OpenYoloCredentialHintOptions): Promise<boolean>;
 
   /**
    * Attempts to retrieve a sign-up hint that can be used to create a new
@@ -68,7 +68,8 @@ export interface OpenYoloApi {
    *     A promise for a credential hint. The promise will be rejected if the
    *     user cancels the hint selection process.
    */
-  hint(options: OYCredentialHintOptions): Promise<OYCredential|null>;
+  hint(options: OpenYoloCredentialHintOptions):
+      Promise<OpenYoloCredential|null>;
 
   /**
    * Attempts to retrieve a credential for the current origin.
@@ -81,7 +82,8 @@ export interface OpenYoloApi {
    *     Otherwise, the promise will resolve with a credential that the app
    *     can use.
    */
-  retrieve(options: OYCredentialRequestOptions): Promise<OYCredential|null>;
+  retrieve(options: OpenYoloCredentialRequestOptions):
+      Promise<OpenYoloCredential|null>;
 
   /**
    * Attempts to save the provided credential, which will update or create
@@ -94,7 +96,7 @@ export interface OpenYoloApi {
    *     resolve, and does not indicate whether the credential was actually
    *     saved.
    */
-  save(credential: OYCredential): Promise<void>;
+  save(credential: OpenYoloCredential): Promise<void>;
 
   /**
    * Prevents the automatic release of a credential from the retrieve operation.
@@ -119,7 +121,8 @@ export interface OpenYoloApi {
    * @return
    *    A promise for the response data from the authentication system.
    */
-  proxyLogin(credential: OYCredential): Promise<OYProxyLoginResponse>;
+  proxyLogin(credential: OpenYoloCredential):
+      Promise<OpenYoloProxyLoginResponse>;
 
   /**
    * Cancels the last pending OpenYOLO request.
@@ -131,16 +134,19 @@ export interface OpenYoloApi {
  * A variant of the OpenYoloApi interface, with support for operation timeouts.
  */
 export interface OpenYoloWithTimeoutApi {
-  hintsAvailable(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
-      Promise<boolean>;
-  hint(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
-      Promise<OYCredential|null>;
-  retrieve(options: OYCredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<OYCredential|null>;
-  save(credential: OYCredential, timeoutRacer: TimeoutRacer): Promise<void>;
+  hintsAvailable(
+      options: OpenYoloCredentialHintOptions,
+      timeoutRacer: TimeoutRacer): Promise<boolean>;
+  hint(options: OpenYoloCredentialHintOptions, timeoutRacer: TimeoutRacer):
+      Promise<OpenYoloCredential|null>;
+  retrieve(
+      options: OpenYoloCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OpenYoloCredential|null>;
+  save(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer):
+      Promise<void>;
   disableAutoSignIn(timeoutRacer: TimeoutRacer): Promise<void>;
-  proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
-      Promise<OYProxyLoginResponse>;
+  proxyLogin(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer):
+      Promise<OpenYoloProxyLoginResponse>;
   cancelLastOperation(timeoutRacer: TimeoutRacer): Promise<void>;
   dispose(): Promise<void>;
 }
@@ -185,19 +191,20 @@ function verifyOrDetectRenderMode(renderMode: RenderMode|null): RenderMode {
  */
 class OpenYoloBrowserApiImpl implements OpenYoloWithTimeoutApi {
   async retrieve(
-      options: OYCredentialRequestOptions,
-      timeoutRacer: TimeoutRacer): Promise<OYCredential|null> {
+      options: OpenYoloCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OpenYoloCredential|null> {
     return Promise.reject('not implemented');
   }
 
   async hintsAvailable(
-      options: OYCredentialRequestOptions,
+      options: OpenYoloCredentialRequestOptions,
       timeoutRacer: TimeoutRacer): Promise<boolean> {
     return Promise.reject('not implemented');
   }
 
-  async hint(options: OYCredentialRequestOptions, timeoutRacer: TimeoutRacer):
-      Promise<OYCredential|null> {
+  async hint(
+      options: OpenYoloCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OpenYoloCredential|null> {
     return Promise.reject('not implemented');
   }
 
@@ -205,13 +212,13 @@ class OpenYoloBrowserApiImpl implements OpenYoloWithTimeoutApi {
     return Promise.reject('not implemented');
   }
 
-  async save(credential: OYCredential, timeoutRacer: TimeoutRacer):
+  async save(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer):
       Promise<void> {
     return Promise.reject('not implemented');
   }
 
-  async proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
-      Promise<OYProxyLoginResponse> {
+  async proxyLogin(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer):
+      Promise<OpenYoloProxyLoginResponse> {
     return Promise.reject('not implemented');
   }
 
@@ -236,7 +243,7 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
       private channel: SecureChannel) {}
 
   async hintsAvailable(
-      options: OYCredentialHintOptions,
+      options: OpenYoloCredentialHintOptions,
       timeoutRacer: TimeoutRacer): Promise<boolean> {
     this.checkNotDisposed();
     const request = new HintAvailableRequest(this.frameManager, this.channel);
@@ -248,29 +255,30 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
     }
   }
 
-  async hint(options: OYCredentialHintOptions, timeoutRacer: TimeoutRacer):
-      Promise<OYCredential|null> {
+  async hint(
+      options: OpenYoloCredentialHintOptions,
+      timeoutRacer: TimeoutRacer): Promise<OpenYoloCredential|null> {
     this.checkNotDisposed();
     const request = new HintRequest(this.frameManager, this.channel);
     return await request.dispatch(options, timeoutRacer);
   }
 
   async retrieve(
-      options: OYCredentialRequestOptions,
-      timeoutRacer: TimeoutRacer): Promise<OYCredential|null> {
+      options: OpenYoloCredentialRequestOptions,
+      timeoutRacer: TimeoutRacer): Promise<OpenYoloCredential|null> {
     this.checkNotDisposed();
     const request = new CredentialRequest(this.frameManager, this.channel);
     return await request.dispatch(options, timeoutRacer);
   }
 
-  async save(credential: OYCredential, timeoutRacer: TimeoutRacer) {
+  async save(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer) {
     this.checkNotDisposed();
     const request = new CredentialSave(this.frameManager, this.channel);
     return await request.dispatch(credential, timeoutRacer);
   }
 
-  async proxyLogin(credential: OYCredential, timeoutRacer: TimeoutRacer):
-      Promise<OYProxyLoginResponse> {
+  async proxyLogin(credential: OpenYoloCredential, timeoutRacer: TimeoutRacer):
+      Promise<OpenYoloProxyLoginResponse> {
     this.checkNotDisposed();
     const request = new ProxyLogin(this.frameManager, this.channel);
     return await request.dispatch(credential, timeoutRacer);
@@ -301,7 +309,7 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
 
   private checkNotDisposed() {
     if (this.disposed) {
-      throw OYInternalError.clientDisposed().toExposedError();
+      throw OpenYoloInternalError.clientDisposed().toExposedError();
     }
   }
 }
@@ -393,7 +401,7 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     } catch (e) {
       timeoutRacer.rethrowUnlessTimeoutError(e);
       // Convert the timeout error.
-      throw OYInternalError.requestTimeout().toExposedError();
+      throw OpenYoloInternalError.requestTimeout().toExposedError();
     }
   }
 
@@ -465,22 +473,24 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
                                          defaultTimeoutMs);
   }
 
-  async hintsAvailable(options: OYCredentialHintOptions): Promise<boolean> {
+  async hintsAvailable(options: OpenYoloCredentialHintOptions):
+      Promise<boolean> {
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.hintsAvailable);
     const impl = await this.init(timeoutRacer);
     return await impl.hintsAvailable(options, timeoutRacer);
   }
 
-  async hint(options: OYCredentialHintOptions): Promise<OYCredential|null> {
+  async hint(options: OpenYoloCredentialHintOptions):
+      Promise<OpenYoloCredential|null> {
     const preloadRequest = {type: PreloadRequestType.hint, options};
     const timeoutRacer = this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.hint);
     const impl = await this.init(timeoutRacer, preloadRequest);
     return await impl.hint(options, timeoutRacer);
   }
 
-  async retrieve(options: OYCredentialRequestOptions):
-      Promise<OYCredential|null> {
+  async retrieve(options: OpenYoloCredentialRequestOptions):
+      Promise<OpenYoloCredential|null> {
     const preloadRequest = {type: PreloadRequestType.retrieve, options};
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.retrieve);
@@ -488,7 +498,7 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     return impl.retrieve(options, timeoutRacer);
   }
 
-  async save(credential: OYCredential): Promise<void> {
+  async save(credential: OpenYoloCredential): Promise<void> {
     const timeoutRacer = this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.save);
     const impl = await this.init(timeoutRacer);
     return impl.save(credential, timeoutRacer);
@@ -501,7 +511,8 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     return impl.disableAutoSignIn(timeoutRacer);
   }
 
-  async proxyLogin(credential: OYCredential): Promise<OYProxyLoginResponse> {
+  async proxyLogin(credential: OpenYoloCredential):
+      Promise<OpenYoloProxyLoginResponse> {
     const timeoutRacer =
         this.startCustomTimeoutRacer(DEFAULT_TIMEOUTS.proxyLogin);
     const impl = await this.init(timeoutRacer);

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -301,7 +301,7 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
 
   private checkNotDisposed() {
     if (this.disposed) {
-      throw OYInternalError.clientDisposed();
+      throw OYInternalError.clientDisposed().toExposedError();
     }
   }
 }
@@ -393,7 +393,7 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     } catch (e) {
       timeoutRacer.rethrowUnlessTimeoutError(e);
       // Convert the timeout error.
-      throw OYInternalError.requestTimeout();
+      throw OYInternalError.requestTimeout().toExposedError();
     }
   }
 

--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -16,7 +16,7 @@
 
 import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
 import {RenderMode} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {PreloadRequest, PreloadRequestType} from '../protocol/preload_request';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, sha256, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
@@ -34,7 +34,7 @@ import {WrapBrowserRequest} from './wrap_browser_request';
 
 // re-export all the data types
 export * from '../protocol/data';
-export {OpenYoloError, InternalErrorCode} from '../protocol/errors';
+export {OYInternalError, InternalErrorCode} from '../protocol/errors';
 
 const MOBILE_USER_AGENT_REGEX = /android|iphone|ipod|iemobile/i;
 
@@ -301,7 +301,7 @@ class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
 
   private checkNotDisposed() {
     if (this.disposed) {
-      throw OpenYoloError.clientDisposed();
+      throw OYInternalError.clientDisposed();
     }
   }
 }
@@ -370,12 +370,8 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
           providerUrlBase,
           preloadRequest);
 
-      const channel =
-          await timeoutRacer.race(SecureChannel.clientConnectNoTimeout(
-              window,
-              frameManager.getContentWindow(),
-              instanceId,
-              instanceIdHash));
+      const channel = await timeoutRacer.race(SecureChannel.clientConnect(
+          window, frameManager.getContentWindow(), instanceId, instanceIdHash));
 
       // Check whether the client should wrap the browser's
       // navigator.credentials.
@@ -397,7 +393,7 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
     } catch (e) {
       timeoutRacer.rethrowUnlessTimeoutError(e);
       // Convert the timeout error.
-      throw OpenYoloError.requestTimeout();
+      throw OYInternalError.requestTimeout();
     }
   }
 

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
 import {SecureChannel} from '../protocol/secure_channel';
 import {PromiseResolver} from '../protocol/utils';
 
@@ -25,7 +25,7 @@ import {WrapBrowserRequest} from './wrap_browser_request';
 type OpenYoloWithTimeoutApiMethods = keyof OpenYoloWithTimeoutApi;
 
 describe('OpenYolo API', () => {
-  const credential: OYCredential = {id: 'test', authMethod: 'test'};
+  const credential: OpenYoloCredential = {id: 'test', authMethod: 'test'};
   const expectedError = new Error('ERROR!');
   const secureChannelSpy =
       jasmine.createSpyObj('SecureChannel', ['send', 'listen', 'dispose']);
@@ -216,7 +216,8 @@ describe('OpenYolo API', () => {
       });
 
       it('hintsAvailable', (done) => {
-        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
+        const options:
+            OpenYoloCredentialHintOptions = {supportedAuthMethods: []};
         openYoloApiImplSpy.hintsAvailable.and.returnValue(
             Promise.resolve(true));
         openyolo.hintsAvailable(options).then((result) => {
@@ -228,7 +229,8 @@ describe('OpenYolo API', () => {
       });
 
       it('hint', (done) => {
-        const options: OYCredentialHintOptions = {supportedAuthMethods: []};
+        const options:
+            OpenYoloCredentialHintOptions = {supportedAuthMethods: []};
         openYoloApiImplSpy.hint.and.returnValue(Promise.resolve(credential));
         openyolo.hint(options).then((cred) => {
           expect(cred).toBe(credential);
@@ -239,7 +241,8 @@ describe('OpenYolo API', () => {
       });
 
       it('retrieve', (done) => {
-        const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
+        const options:
+            OpenYoloCredentialRequestOptions = {supportedAuthMethods: []};
         openYoloApiImplSpy.retrieve.and.returnValue(
             Promise.resolve(credential));
         openyolo.retrieve(options).then((cred) => {
@@ -251,8 +254,10 @@ describe('OpenYolo API', () => {
       });
 
       it('proxyLogin', (done) => {
-        const expectedResponse:
-            OYProxyLoginResponse = {statusCode: 200, responseText: 'test'};
+        const expectedResponse: OpenYoloProxyLoginResponse = {
+          statusCode: 200,
+          responseText: 'test'
+        };
         openYoloApiImplSpy.proxyLogin.and.returnValue(
             Promise.resolve(expectedResponse));
         openyolo.proxyLogin(credential).then((response) => {

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -93,7 +93,7 @@ describe('OpenYolo API', () => {
     });
 
     it('secure channel connection fails', (done) => {
-      spyOn(SecureChannel, 'clientConnectNoTimeout')
+      spyOn(SecureChannel, 'clientConnect')
           .and.returnValue(Promise.reject(expectedError));
       // The operation does not matter here.
       openyolo.disableAutoSignIn().then(
@@ -108,7 +108,7 @@ describe('OpenYolo API', () => {
     });
 
     it('wrap browser fails', (done) => {
-      spyOn(SecureChannel, 'clientConnectNoTimeout')
+      spyOn(SecureChannel, 'clientConnect')
           .and.returnValue(Promise.resolve(secureChannelSpy));
       spyOn(WrapBrowserRequest.prototype, 'dispatch')
           .and.returnValue(Promise.reject(expectedError));
@@ -127,7 +127,7 @@ describe('OpenYolo API', () => {
     });
 
     it('wrap browser succeeds', (done) => {
-      spyOn(SecureChannel, 'clientConnectNoTimeout')
+      spyOn(SecureChannel, 'clientConnect')
           .and.returnValue(Promise.resolve(secureChannelSpy));
       spyOn(WrapBrowserRequest.prototype, 'dispatch')
           .and.returnValue(Promise.resolve(false));
@@ -155,7 +155,7 @@ describe('OpenYolo API', () => {
 
       it('timeouts disabled', (done) => {
         const promiseResolver = new PromiseResolver<void>();
-        spyOn(SecureChannel, 'clientConnectNoTimeout')
+        spyOn(SecureChannel, 'clientConnect')
             .and.returnValue(promiseResolver.promise);
         spyOn(WrapBrowserRequest.prototype, 'dispatch')
             .and.returnValue(Promise.resolve(false));
@@ -178,7 +178,7 @@ describe('OpenYolo API', () => {
 
       it('custom timeouts set', (done) => {
         const promiseResolver = new PromiseResolver<void>();
-        spyOn(SecureChannel, 'clientConnectNoTimeout')
+        spyOn(SecureChannel, 'clientConnect')
             .and.returnValue(promiseResolver.promise);
         let timeoutExpired = false;
         openyolo.setTimeouts(100);

--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {InternalErrorCode, OpenYoloError, OpenYoloErrorData, OpenYoloExtendedError} from '../protocol/errors';
+import {InternalErrorCode, OYErrorData, OYInternalError} from '../protocol/errors';
 import {RpcMessageArgumentTypes, RpcMessageData, RpcMessageType} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, PromiseResolver, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
@@ -75,7 +75,7 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
       // Handle specifically a timeout error.
       this.frame.hide();
       this.dispose();
-      throw OpenYoloError.requestTimeout();
+      throw OYInternalError.requestTimeout();
     }
   }
 
@@ -91,12 +91,12 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
   private registerBaseHandlers() {
     this.debugLog('request instantiated');
     // Register a standard error handler.
-    this.registerHandler(RpcMessageType.error, (data: OpenYoloErrorData) => {
-      let error: OpenYoloExtendedError;
+    this.registerHandler(RpcMessageType.error, (data: OYErrorData) => {
+      let error: OYInternalError;
       if (data) {
-        error = OpenYoloError.createError(data);
+        error = new OYInternalError(data);
       } else {
-        error = OpenYoloError.unknown();
+        error = OYInternalError.unknownError();
       }
 
       this.debugLog(`request failed: ${error}`);
@@ -126,7 +126,7 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
     this.frame.hide();
   }
 
-  reject(reason: OpenYoloExtendedError) {
+  reject(reason: OYInternalError) {
     this.promiseResolver.reject(reason);
     // Do not hide the IFrame in case of concurrent request, to allow the
     // previous one to finish.

--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloError, OpenYoloErrorType, OYExposedErrorData, OYInternalError} from '../protocol/errors';
+import {OpenYoloError, OpenYoloErrorType, OpenYoloExposedErrorData, OpenYoloInternalError} from '../protocol/errors';
 import {RpcMessageArgumentTypes, RpcMessageData, RpcMessageType} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, PromiseResolver, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
@@ -75,7 +75,7 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
       // Handle specifically a timeout error.
       this.frame.hide();
       this.dispose();
-      throw OYInternalError.requestTimeout().toExposedError();
+      throw OpenYoloInternalError.requestTimeout().toExposedError();
     }
   }
 
@@ -91,18 +91,19 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
   private registerBaseHandlers() {
     this.debugLog('request instantiated');
     // Register a standard error handler.
-    this.registerHandler(RpcMessageType.error, (data: OYExposedErrorData) => {
-      let error: OpenYoloError;
-      if (data) {
-        error = OpenYoloError.fromData(data);
-      } else {
-        error = OYInternalError.unknownError().toExposedError();
-      }
+    this.registerHandler(
+        RpcMessageType.error, (data: OpenYoloExposedErrorData) => {
+          let error: OpenYoloError;
+          if (data) {
+            error = OpenYoloError.fromData(data);
+          } else {
+            error = OpenYoloInternalError.unknownError().toExposedError();
+          }
 
-      this.debugLog(`request failed: ${error}`);
-      this.reject(error);
-      this.dispose();
-    });
+          this.debugLog(`request failed: ${error}`);
+          this.reject(error);
+          this.dispose();
+        });
 
     // Register a standard handler for displaying the provider - when UI is
     // shown, the timeouts are also canceled to allow the operation to proceed

--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
+import {InternalErrorCode, OYInternalError} from '../protocol/errors';
 import {errorMessage, noneAvailableMessage, RpcMessageType, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {startTimeoutRacer} from '../protocol/utils';
@@ -97,7 +97,7 @@ describe('BaseRequest', () => {
                 done.fail('Should not be a success!');
               },
               (error) => {
-                expect(OpenYoloError.errorIs(
+                expect(OYInternalError.errorIs(
                            error, InternalErrorCode.requestTimeout))
                     .toBe(true);
                 expect(frame.hide).toHaveBeenCalled();
@@ -146,7 +146,7 @@ describe('BaseRequest', () => {
     });
 
     it('listens to error and disposes', async function(done) {
-      const expectedError = OpenYoloError.illegalStateError('ERROR!');
+      const expectedError = OYInternalError.illegalStateError('ERROR!');
       const promise = request.dispatch(undefined);
       providerChannel.send(errorMessage(request.id, expectedError));
       try {
@@ -162,7 +162,7 @@ describe('BaseRequest', () => {
 
     it('listens to illegalConcurrentError and disposes but not hide the iframe',
        async function(done) {
-         const expectedError = OpenYoloError.illegalConcurrentRequestError();
+         const expectedError = OYInternalError.illegalConcurrentRequestError();
          const promise = request.dispatch(undefined);
          providerChannel.send(errorMessage(request.id, expectedError));
          try {

--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {InternalErrorCode, OYInternalError} from '../protocol/errors';
+import {OpenYoloErrorType, OYInternalError} from '../protocol/errors';
 import {errorMessage, noneAvailableMessage, RpcMessageType, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {startTimeoutRacer} from '../protocol/utils';
@@ -97,9 +97,7 @@ describe('BaseRequest', () => {
                 done.fail('Should not be a success!');
               },
               (error) => {
-                expect(OYInternalError.errorIs(
-                           error, InternalErrorCode.requestTimeout))
-                    .toBe(true);
+                expect(error.type).toEqual(OpenYoloErrorType.requestFailed);
                 expect(frame.hide).toHaveBeenCalled();
                 done();
               });
@@ -146,7 +144,8 @@ describe('BaseRequest', () => {
     });
 
     it('listens to error and disposes', async function(done) {
-      const expectedError = OYInternalError.illegalStateError('ERROR!');
+      const expectedError =
+          OYInternalError.illegalStateError('ERROR!').toExposedError();
       const promise = request.dispatch(undefined);
       providerChannel.send(errorMessage(request.id, expectedError));
       try {
@@ -162,7 +161,8 @@ describe('BaseRequest', () => {
 
     it('listens to illegalConcurrentError and disposes but not hide the iframe',
        async function(done) {
-         const expectedError = OYInternalError.illegalConcurrentRequestError();
+         const expectedError =
+             OYInternalError.illegalConcurrentRequestError().toExposedError();
          const promise = request.dispatch(undefined);
          providerChannel.send(errorMessage(request.id, expectedError));
          try {

--- a/ts/api/base_request_test.ts
+++ b/ts/api/base_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloErrorType, OYInternalError} from '../protocol/errors';
+import {OpenYoloErrorType, OpenYoloInternalError} from '../protocol/errors';
 import {errorMessage, noneAvailableMessage, RpcMessageType, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {startTimeoutRacer} from '../protocol/utils';
@@ -145,7 +145,7 @@ describe('BaseRequest', () => {
 
     it('listens to error and disposes', async function(done) {
       const expectedError =
-          OYInternalError.illegalStateError('ERROR!').toExposedError();
+          OpenYoloInternalError.illegalStateError('ERROR!').toExposedError();
       const promise = request.dispatch(undefined);
       providerChannel.send(errorMessage(request.id, expectedError));
       try {
@@ -162,7 +162,8 @@ describe('BaseRequest', () => {
     it('listens to illegalConcurrentError and disposes but not hide the iframe',
        async function(done) {
          const expectedError =
-             OYInternalError.illegalConcurrentRequestError().toExposedError();
+             OpenYoloInternalError.illegalConcurrentRequestError()
+                 .toExposedError();
          const promise = request.dispatch(undefined);
          providerChannel.send(errorMessage(request.id, expectedError));
          try {

--- a/ts/api/credential_request.ts
+++ b/ts/api/credential_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYCredentialRequestOptions} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {retrieveMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -23,17 +23,18 @@ import {BaseRequest} from './base_request';
  * Handles the get credential request, by displaying the IFrame or not to let
  * the user selects a credential, if any is available.
  */
-export class CredentialRequest extends
-    BaseRequest<OYCredential|null, OYCredentialRequestOptions|undefined> {
+export class CredentialRequest extends BaseRequest<
+    OpenYoloCredential|null,
+    OpenYoloCredentialRequestOptions|undefined> {
   /**
    * Starts the Credential Request flow.
    */
-  dispatchInternal(options: OYCredentialRequestOptions) {
+  dispatchInternal(options: OpenYoloCredentialRequestOptions) {
     // the final outcome will either be a credential, or a notification that
     // none are available / none was selected by the user.
     this.registerHandler(
         RpcMessageType.credential,
-        (credential: OYCredential) => this.handleResult(credential));
+        (credential: OpenYoloCredential) => this.handleResult(credential));
     this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     // send the request
@@ -43,7 +44,7 @@ export class CredentialRequest extends
   /**
    * Handles the initial response from a credential request.
    */
-  private handleResult(credential: OYCredential|null): void {
+  private handleResult(credential: OpenYoloCredential|null): void {
     this.resolve(credential);
     this.dispose();
   }

--- a/ts/api/credential_request_test.ts
+++ b/ts/api/credential_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, OYCredential, OYCredentialRequestOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {credentialResultMessage, noneAvailableMessage, retrieveMessage, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -29,7 +29,7 @@ describe('CredentialRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: ProviderFrameElement;
-  const options: OYCredentialRequestOptions = {supportedAuthMethods: []};
+  const options: OpenYoloCredentialRequestOptions = {supportedAuthMethods: []};
 
   beforeEach(() => {
     connection = new FakeProviderConnection();
@@ -48,7 +48,7 @@ describe('CredentialRequest', () => {
   describe('dispatch', () => {
     it('should send a RPC message through the channel', () => {
       spyOn(clientChannel, 'send').and.callThrough();
-      let options: OYCredentialRequestOptions = {
+      let options: OpenYoloCredentialRequestOptions = {
         supportedAuthMethods: ['openyolo://id-and-password']
       };
       request.dispatch(options);
@@ -78,7 +78,7 @@ describe('CredentialRequest', () => {
     });
 
     it('should resolve with credential on success', async function(done) {
-      let credential: OYCredential = {
+      let credential: OpenYoloCredential = {
         id: 'alice@gmail.com',
         authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
         displayName: 'Google'

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -26,7 +26,7 @@ export class CredentialSave extends BaseRequest<void, OYCredential> {
       if (saved) {
         this.resolve();
       } else {
-        this.reject(OYInternalError.userCanceled());
+        this.reject(OYInternalError.userCanceled().toExposedError());
       }
       this.dispose();
     });

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import {OYCredential} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {OpenYoloCredential} from '../protocol/data';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {RpcMessageType, saveMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
 
-export class CredentialSave extends BaseRequest<void, OYCredential> {
-  dispatchInternal(credential: OYCredential) {
+export class CredentialSave extends BaseRequest<void, OpenYoloCredential> {
+  dispatchInternal(credential: OpenYoloCredential) {
     this.registerHandler(RpcMessageType.saveResult, (saved: boolean) => {
       if (saved) {
         this.resolve();
       } else {
-        this.reject(OYInternalError.userCanceled().toExposedError());
+        this.reject(OpenYoloInternalError.userCanceled().toExposedError());
       }
       this.dispose();
     });

--- a/ts/api/credential_save.ts
+++ b/ts/api/credential_save.ts
@@ -15,7 +15,7 @@
  */
 
 import {OYCredential} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {RpcMessageType, saveMessage} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -26,7 +26,7 @@ export class CredentialSave extends BaseRequest<void, OYCredential> {
       if (saved) {
         this.resolve();
       } else {
-        this.reject(OpenYoloError.canceled());
+        this.reject(OYInternalError.userCanceled());
       }
       this.dispose();
     });

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {OYCredential} from '../protocol/data';
+import {OpenYoloCredential} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {OpenYoloErrorType, OYInternalError} from '../protocol/errors';
+import {OpenYoloErrorType, OpenYoloInternalError} from '../protocol/errors';
 import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -29,7 +29,7 @@ describe('CredentialSave', () => {
   let providerChannel: SecureChannel;
   let request: CredentialSave;
   let frame: any;
-  let credential: OYCredential = {
+  let credential: OpenYoloCredential = {
     id: 'user@example.com',
     authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
     displayName: 'User',
@@ -87,7 +87,8 @@ describe('CredentialSave', () => {
     let promise = request.dispatch(credential);
 
     providerChannel.send(errorMessage(
-        request.id, OYInternalError.requestFailed('ERROR!').toExposedError()));
+        request.id,
+        OpenYoloInternalError.requestFailed('ERROR!').toExposedError()));
     try {
       await promise;
       done.fail('Promise should be rejected');

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -16,7 +16,7 @@
 
 import {OYCredential} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {InternalErrorCode, OYInternalError} from '../protocol/errors';
+import {OpenYoloErrorType, OYInternalError} from '../protocol/errors';
 import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -77,8 +77,7 @@ describe('CredentialSave', () => {
       await promise;
       done.fail('promise should be rejected');
     } catch (err) {
-      expect(OYInternalError.errorIs(err, InternalErrorCode.userCanceled))
-          .toBeTruthy();
+      expect(err.type).toEqual(OpenYoloErrorType.userCanceled);
       expect(request.dispose).toHaveBeenCalled();
       done();
     }
@@ -87,14 +86,13 @@ describe('CredentialSave', () => {
   it('should reject if error received', async function(done) {
     let promise = request.dispatch(credential);
 
-    providerChannel.send(
-        errorMessage(request.id, OYInternalError.requestFailed('ERROR!')));
+    providerChannel.send(errorMessage(
+        request.id, OYInternalError.requestFailed('ERROR!').toExposedError()));
     try {
       await promise;
       done.fail('Promise should be rejected');
     } catch (err) {
-      expect(OYInternalError.errorIs(err, InternalErrorCode.requestFailed))
-          .toBeTruthy();
+      expect(err.type).toEqual(OpenYoloErrorType.requestFailed);
       expect(request.dispose).toHaveBeenCalled();
       done();
     }

--- a/ts/api/credential_save_test.ts
+++ b/ts/api/credential_save_test.ts
@@ -16,7 +16,7 @@
 
 import {OYCredential} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
+import {InternalErrorCode, OYInternalError} from '../protocol/errors';
 import {errorMessage, saveMessage, saveResultMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -77,7 +77,7 @@ describe('CredentialSave', () => {
       await promise;
       done.fail('promise should be rejected');
     } catch (err) {
-      expect(OpenYoloError.errorIs(err, InternalErrorCode.userCanceled))
+      expect(OYInternalError.errorIs(err, InternalErrorCode.userCanceled))
           .toBeTruthy();
       expect(request.dispose).toHaveBeenCalled();
       done();
@@ -88,12 +88,12 @@ describe('CredentialSave', () => {
     let promise = request.dispatch(credential);
 
     providerChannel.send(
-        errorMessage(request.id, OpenYoloError.requestFailed('ERROR!')));
+        errorMessage(request.id, OYInternalError.requestFailed('ERROR!')));
     try {
       await promise;
       done.fail('Promise should be rejected');
     } catch (err) {
-      expect(OpenYoloError.errorIs(err, InternalErrorCode.requestFailed))
+      expect(OYInternalError.errorIs(err, InternalErrorCode.requestFailed))
           .toBeTruthy();
       expect(request.dispose).toHaveBeenCalled();
       done();

--- a/ts/api/hint_available_request.ts
+++ b/ts/api/hint_available_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYCredentialHintOptions} from '../protocol/data';
+import {OpenYoloCredentialHintOptions} from '../protocol/data';
 import {hintAvailableMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -24,11 +24,11 @@ import {BaseRequest} from './base_request';
  * any user interaction, and if fails, just return as if there was no hints.
  */
 export class HintAvailableRequest extends
-    BaseRequest<boolean, OYCredentialHintOptions> {
+    BaseRequest<boolean, OpenYoloCredentialHintOptions> {
   /**
    * Sends the RPC to the IFrame and waits for the result.
    */
-  dispatchInternal(options: OYCredentialHintOptions) {
+  dispatchInternal(options: OpenYoloCredentialHintOptions) {
     this.registerHandler(
         RpcMessageType.hintAvailableResult, (available: boolean) => {
           this.resolve(available);

--- a/ts/api/hint_available_request_test.ts
+++ b/ts/api/hint_available_request_test.ts
@@ -15,7 +15,7 @@
  */
 
 import {AUTHENTICATION_METHODS, OYCredentialHintOptions} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {errorMessage, hintAvailableMessage, hintAvailableResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -84,7 +84,7 @@ describe('HintAvailableRequest', () => {
 
   it('should fail if error returned', async function(done) {
     let promise = request.dispatch(passwordOnlyOptions);
-    let expectedError = OpenYoloError.requestFailed('error!');
+    let expectedError = OYInternalError.requestFailed('error!');
     providerChannel.send(errorMessage(request.id, expectedError));
 
     try {

--- a/ts/api/hint_available_request_test.ts
+++ b/ts/api/hint_available_request_test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, OYCredentialHintOptions} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {AUTHENTICATION_METHODS, OpenYoloCredentialHintOptions} from '../protocol/data';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {errorMessage, hintAvailableMessage, hintAvailableResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -28,7 +28,7 @@ describe('HintAvailableRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let passwordOnlyOptions: OYCredentialHintOptions = {
+  let passwordOnlyOptions: OpenYoloCredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
 
@@ -85,7 +85,7 @@ describe('HintAvailableRequest', () => {
   it('should fail if error returned', async function(done) {
     let promise = request.dispatch(passwordOnlyOptions);
     let expectedError =
-        OYInternalError.requestFailed('error!').toExposedError();
+        OpenYoloInternalError.requestFailed('error!').toExposedError();
     providerChannel.send(errorMessage(request.id, expectedError));
 
     try {

--- a/ts/api/hint_available_request_test.ts
+++ b/ts/api/hint_available_request_test.ts
@@ -84,7 +84,8 @@ describe('HintAvailableRequest', () => {
 
   it('should fail if error returned', async function(done) {
     let promise = request.dispatch(passwordOnlyOptions);
-    let expectedError = OYInternalError.requestFailed('error!');
+    let expectedError =
+        OYInternalError.requestFailed('error!').toExposedError();
     providerChannel.send(errorMessage(request.id, expectedError));
 
     try {

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYCredentialHintOptions} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloCredentialHintOptions} from '../protocol/data';
 import {hintMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -23,15 +23,16 @@ import {BaseRequest} from './base_request';
  * Handles the get hint request, by displaying the IFrame or not to let
  * the user selects a hint, if any is available.
  */
-export class HintRequest extends
-    BaseRequest<OYCredential|null, OYCredentialHintOptions|undefined> {
+export class HintRequest extends BaseRequest<
+    OpenYoloCredential|null,
+    OpenYoloCredentialHintOptions|undefined> {
   /**
    * Starts the Hint Request flow.
    */
-  dispatchInternal(options: OYCredentialHintOptions) {
+  dispatchInternal(options: OpenYoloCredentialHintOptions) {
     this.registerHandler(
         RpcMessageType.credential,
-        (credential: OYCredential) => this.handleResult(credential));
+        (credential: OpenYoloCredential) => this.handleResult(credential));
     this.registerHandler(RpcMessageType.none, () => this.handleResult(null));
 
     this.debugLog(`Sending hint request`);
@@ -41,7 +42,7 @@ export class HintRequest extends
   /**
    * Handles the initial response from a hint request.
    */
-  private handleResult(credential: OYCredential|null): void {
+  private handleResult(credential: OpenYoloCredential|null): void {
     this.debugLog(`Hint request complete`);
     this.resolve(credential);
     this.dispose();

--- a/ts/api/hint_request_test.ts
+++ b/ts/api/hint_request_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, OYCredential, OYCredentialHintOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions} from '../protocol/data';
 import {credentialResultMessage, hintMessage, noneAvailableMessage, showProviderMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -27,8 +27,8 @@ describe('HintRequest', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let hint: OYCredential;
-  let passwordOnlyOptions: OYCredentialHintOptions = {
+  let hint: OpenYoloCredential;
+  let passwordOnlyOptions: OpenYoloCredentialHintOptions = {
     supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
   };
 
@@ -54,7 +54,7 @@ describe('HintRequest', () => {
   describe('dispatch', () => {
     it('should send a RPC message to the frame', () => {
       spyOn(clientChannel, 'send').and.callThrough();
-      let options: OYCredentialHintOptions = {
+      let options: OpenYoloCredentialHintOptions = {
         supportedAuthMethods: ['openyolo://id-and-password']
       };
       request.dispatch(options);

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -15,7 +15,7 @@
  */
 
 import {AUTHENTICATION_METHODS, OYCredential as OpenYoloCredential, OYCredentialHintOptions, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 
 import {OpenYoloApi} from './api';
 
@@ -152,7 +152,7 @@ export class NavigatorCredentials implements OpenYoloApi {
     let convertedOptions = convertRequestOptions(options);
     return this.cmApi.get(convertedOptions).then((cred) => {
       if (!cred) {
-        throw OpenYoloError.canceled();
+        throw OYInternalError.userCanceled();
       }
       this.credentialsMap.insert(cred);
       return convertCredentialToOpenYolo(
@@ -170,7 +170,7 @@ export class NavigatorCredentials implements OpenYoloApi {
 
   hint(options?: OYCredentialHintOptions): Promise<OpenYoloCredential> {
     // Reject with a canceled error as no hints can be retrieved.
-    return Promise.reject(OpenYoloError.canceled());
+    return Promise.reject(OYInternalError.userCanceled());
   }
 
   hintsAvailable(): Promise<boolean> {
@@ -178,7 +178,7 @@ export class NavigatorCredentials implements OpenYoloApi {
   }
 
   cancelLastOperation(): Promise<void> {
-    return Promise.reject(OpenYoloError.apiDisabled());
+    return Promise.reject(OYInternalError.apiDisabled());
   }
 
   proxyLogin(credential: OpenYoloCredential): Promise<OYProxyLoginResponse> {
@@ -193,8 +193,8 @@ export class NavigatorCredentials implements OpenYoloApi {
     return new Promise<OYProxyLoginResponse>((resolve, reject) => {
       fetch(url, {method: 'POST', credentials: cred}).then(resp => {
         if (resp.status !== 200) {
-          reject(
-              OpenYoloError.requestFailed(`Error: status code ${resp.status}`));
+          reject(OYInternalError.requestFailed(
+              `Error: status code ${resp.status}`));
         }
         resp.text().then(responseText => {
           resolve({statusCode: resp.status, responseText: responseText});

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, OYCredential as OpenYoloCredential, OYCredentialHintOptions, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions, OYProxyLoginResponse} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
+import {OpenYoloInternalError} from '../protocol/errors';
 
 import {OpenYoloApi} from './api';
 
@@ -152,7 +152,7 @@ export class NavigatorCredentials implements OpenYoloApi {
     let convertedOptions = convertRequestOptions(options);
     return this.cmApi.get(convertedOptions).then((cred) => {
       if (!cred) {
-        throw OYInternalError.userCanceled();
+        throw OpenYoloInternalError.userCanceled();
       }
       this.credentialsMap.insert(cred);
       return convertCredentialToOpenYolo(
@@ -168,9 +168,9 @@ export class NavigatorCredentials implements OpenYoloApi {
     });
   }
 
-  hint(options?: OYCredentialHintOptions): Promise<OpenYoloCredential> {
+  hint(options?: OpenYoloCredentialHintOptions): Promise<OpenYoloCredential> {
     // Reject with a canceled error as no hints can be retrieved.
-    return Promise.reject(OYInternalError.userCanceled());
+    return Promise.reject(OpenYoloInternalError.userCanceled());
   }
 
   hintsAvailable(): Promise<boolean> {
@@ -178,10 +178,11 @@ export class NavigatorCredentials implements OpenYoloApi {
   }
 
   cancelLastOperation(): Promise<void> {
-    return Promise.reject(OYInternalError.apiDisabled());
+    return Promise.reject(OpenYoloInternalError.apiDisabled());
   }
 
-  proxyLogin(credential: OpenYoloCredential): Promise<OYProxyLoginResponse> {
+  proxyLogin(credential: OpenYoloCredential):
+      Promise<OpenYoloProxyLoginResponse> {
     // TODO(tch): Fetch the URL from configuration.
     let url = `${window.location.protocol}//${window.location.host}/signin`;
     const cred = this.credentialsMap.retrieve(
@@ -190,11 +191,11 @@ export class NavigatorCredentials implements OpenYoloApi {
       return Promise.reject(new Error('Invalid credential!'));
     }
 
-    return new Promise<OYProxyLoginResponse>((resolve, reject) => {
+    return new Promise<OpenYoloProxyLoginResponse>((resolve, reject) => {
       fetch(url, {method: 'POST', credentials: cred}).then(resp => {
         if (resp.status !== 200) {
-          reject(OYInternalError.requestFailed(
-              `Error: status code ${resp.status}`));
+          reject(OpenYoloInternalError.requestFailed(
+              `Status code ${resp.status}`));
         }
         resp.text().then(responseText => {
           resolve({statusCode: resp.status, responseText: responseText});

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -16,7 +16,7 @@
 
 import {OYCredential as OpenYoloCredential, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {InternalErrorCode, OpenYoloError} from '../protocol/errors';
+import {InternalErrorCode, OYInternalError} from '../protocol/errors';
 
 import {NavigatorCredentials} from './navigator_credentials';
 
@@ -103,7 +103,7 @@ describe('NavigatorCredentials', () => {
           },
           (error) => {
             expect(
-                OpenYoloError.errorIs(error, InternalErrorCode.userCanceled));
+                OYInternalError.errorIs(error, InternalErrorCode.userCanceled));
             done();
           });
     });
@@ -254,7 +254,10 @@ describe('NavigatorCredentials', () => {
               done.fail('Unexpected success!');
             },
             (error) => {
-              expect(error.message).toEqual('Error: status code 400');
+              expect(error.message)
+                  .toEqual(
+                      'The API request failed to resolve: Error: status code ' +
+                      '400');
               done();
             });
       });

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {OYCredential as OpenYoloCredential, OYCredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
+import {OpenYoloCredential as OpenYoloCredential, OpenYoloCredentialRequestOptions as OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {AUTHENTICATION_METHODS} from '../protocol/data';
-import {InternalErrorCode, OYInternalError} from '../protocol/errors';
+import {InternalErrorCode, OpenYoloInternalError} from '../protocol/errors';
 
 import {NavigatorCredentials} from './navigator_credentials';
 
@@ -102,8 +102,8 @@ describe('NavigatorCredentials', () => {
             done.fail('Should not resolve!');
           },
           (error) => {
-            expect(
-                OYInternalError.errorIs(error, InternalErrorCode.userCanceled));
+            expect(OpenYoloInternalError.errorIs(
+                error, InternalErrorCode.userCanceled));
             done();
           });
     });
@@ -256,8 +256,7 @@ describe('NavigatorCredentials', () => {
             (error) => {
               expect(error.message)
                   .toEqual(
-                      'The API request failed to resolve: Error: status code ' +
-                      '400');
+                      'The API request failed to resolve: Status code 400');
               done();
             });
       });

--- a/ts/api/proxy_login.ts
+++ b/ts/api/proxy_login.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYProxyLoginResponse} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloProxyLoginResponse} from '../protocol/data';
 import {proxyLoginMessage, RpcMessageType} from '../protocol/rpc_messages';
 
 import {BaseRequest} from './base_request';
@@ -23,13 +23,13 @@ import {BaseRequest} from './base_request';
  * Handles the proxy login.
  */
 export class ProxyLogin extends
-    BaseRequest<OYProxyLoginResponse, OYCredential> {
+    BaseRequest<OpenYoloProxyLoginResponse, OpenYoloCredential> {
   /**
    * Starts the Proxy Login flow.
    */
-  dispatchInternal(credential: OYCredential) {
+  dispatchInternal(credential: OpenYoloCredential) {
     this.registerHandler(
-        RpcMessageType.proxyResult, (response: OYProxyLoginResponse) => {
+        RpcMessageType.proxyResult, (response: OpenYoloProxyLoginResponse) => {
           this.resolve(response);
           this.dispose();
         });

--- a/ts/api/proxy_login_test.ts
+++ b/ts/api/proxy_login_test.ts
@@ -86,7 +86,8 @@ describe('ProxyLogin', () => {
     it('rejects if an error message is received', async function(done) {
       let promise = request.dispatch(credential);
 
-      let expectedError = OYInternalError.requestFailed('error!');
+      let expectedError =
+          OYInternalError.requestFailed('error!').toExposedError();
       providerChannel.send(errorMessage(request.id, expectedError));
 
       try {

--- a/ts/api/proxy_login_test.ts
+++ b/ts/api/proxy_login_test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {AUTHENTICATION_METHODS, OYCredential} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {AUTHENTICATION_METHODS, OpenYoloCredential} from '../protocol/data';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {errorMessage, proxyLoginMessage, proxyLoginResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -28,7 +28,7 @@ describe('ProxyLogin', () => {
   let clientChannel: SecureChannel;
   let providerChannel: SecureChannel;
   let frame: any;
-  let credential: OYCredential = {
+  let credential: OpenYoloCredential = {
     id: 'user@example.com',
     displayName: 'User',
     password: 'password',
@@ -87,7 +87,7 @@ describe('ProxyLogin', () => {
       let promise = request.dispatch(credential);
 
       let expectedError =
-          OYInternalError.requestFailed('error!').toExposedError();
+          OpenYoloInternalError.requestFailed('error!').toExposedError();
       providerChannel.send(errorMessage(request.id, expectedError));
 
       try {

--- a/ts/api/proxy_login_test.ts
+++ b/ts/api/proxy_login_test.ts
@@ -15,7 +15,7 @@
  */
 
 import {AUTHENTICATION_METHODS, OYCredential} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {errorMessage, proxyLoginMessage, proxyLoginResponseMessage} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {FakeProviderConnection} from '../test_utils/channels';
@@ -86,7 +86,7 @@ describe('ProxyLogin', () => {
     it('rejects if an error message is received', async function(done) {
       let promise = request.dispatch(credential);
 
-      let expectedError = OpenYoloError.requestFailed('error!');
+      let expectedError = OYInternalError.requestFailed('error!');
       providerChannel.send(errorMessage(request.id, expectedError));
 
       try {

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -26,7 +26,7 @@ import {PasswordSpecification} from './password_spec';
 /**
  * Represents a credential which may be usable to sign in.
  */
-export interface OYCredential {
+export interface OpenYoloCredential {
   /**
    * The unique identifier for the credential within the scope of the
    * authentication system. This is typically an email address, phone number
@@ -102,7 +102,7 @@ export interface OYCredential {
 /**
  * Encapsulates the response from the authentication system to a proxy login.
  */
-export interface OYProxyLoginResponse {
+export interface OpenYoloProxyLoginResponse {
   statusCode: number;
   responseText: string;
 }
@@ -111,7 +111,7 @@ export interface OYProxyLoginResponse {
  * The set of parameters passed from the client for a credential retrieval
  * request.
  */
-export interface OYCredentialRequestOptions {
+export interface OpenYoloCredentialRequestOptions {
   /**
    * The supported authentication methods supported by the origin, described
    * as a list of absolute, hierarchical URLs with no path. See
@@ -151,7 +151,7 @@ export interface TokenProvider {
 /**
  * The set of parameters passed from the client for a hint retrieval request.
  */
-export interface OYCredentialHintOptions {
+export interface OpenYoloCredentialHintOptions {
   /**
    * The supported authentication methods supported by the origin, described
    * as a list of absolute, hierarchical URLs with no path. See

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -52,7 +52,7 @@ export enum OpenYoloErrorType {
  * Data containing additional information on the error, used only in the
  * provider frame.
  */
-export interface OYErrorData {
+export interface OpenYoloErrorData {
   /** Standardized error code. */
   code: InternalErrorCode;
   /** Type of the corresponding exposed error. */
@@ -68,7 +68,7 @@ export interface OYErrorData {
  * sensitive data. It is the interface of the object sent through the
  * SecureChannel to the client.
  */
-export interface OYExposedErrorData {
+export interface OpenYoloExposedErrorData {
   /** Standardized exposed error type. */
   type: OpenYoloErrorType;
   /**
@@ -81,8 +81,8 @@ export interface OYExposedErrorData {
 /**
  * Internal error.
  */
-export class OYInternalError extends Error {
-  constructor(public data: OYErrorData) {
+export class OpenYoloInternalError extends Error {
+  constructor(public data: OpenYoloErrorData) {
     super(data.message);
   }
 
@@ -92,7 +92,7 @@ export class OYInternalError extends Error {
   }
 
   /** Returns the client-side exposed error data. */
-  private toExposedErrorData(): OYExposedErrorData {
+  private toExposedErrorData(): OpenYoloExposedErrorData {
     return {
       type: this.data.exposedErrorType,
       message: `${this.data.code}: ${this.data.message}`
@@ -102,7 +102,7 @@ export class OYInternalError extends Error {
   /* Initialization errors. */
 
   static ackTimeout() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.ackTimeout,
       exposedErrorType: OpenYoloErrorType.initializationError,
       message: 'A parent frame failed to acknowledge the handshake. This can ' +
@@ -112,7 +112,7 @@ export class OYInternalError extends Error {
   }
 
   static establishSecureChannelTimeout() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.establishSecureChannelTimeout,
       exposedErrorType: OpenYoloErrorType.initializationError,
       message: 'The Secure Channel failed to initialize in a timely manner. ' +
@@ -121,7 +121,7 @@ export class OYInternalError extends Error {
   }
 
   static parentVerifyTimeout() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.parentVerifyTimeout,
       exposedErrorType: OpenYoloErrorType.initializationError,
       message: 'The credentials provider frame failed to verify the ancestor ' +
@@ -130,7 +130,7 @@ export class OYInternalError extends Error {
   }
 
   static illegalStateError(reason: string) {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.illegalStateError,
       exposedErrorType: OpenYoloErrorType.initializationError,
       message: `An internal error happened: ${reason}`
@@ -138,28 +138,27 @@ export class OYInternalError extends Error {
   }
 
   static providerInitializationFailed() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.providerInitializationFailed,
       exposedErrorType: OpenYoloErrorType.initializationError,
-      message: 'The credentials provider frame failed to verify the ancestor ' +
-          'frames in a timely manner.'
+      message: 'The credentials provider frame failed to initialize.'
     });
   }
 
   static apiDisabled() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.apiDisabled,
       exposedErrorType: OpenYoloErrorType.initializationError,
       message:
           'The API has been disabled by the user’s preference or has not been' +
-          'enabled in the OpenYolo configuration.'
+          ' enabled in the OpenYolo configuration.'
     });
   }
 
   /* Configuration errors. */
 
   static untrustedOrigin(origin: string) {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.untrustedOrigin,
       exposedErrorType: OpenYoloErrorType.configurationError,
       message: `A parent frame does not belong to an authorized origin. ` +
@@ -168,7 +167,7 @@ export class OYInternalError extends Error {
   }
 
   static parentIsNotRoot() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.parentIsNotRoot,
       exposedErrorType: OpenYoloErrorType.configurationError,
       message:
@@ -180,7 +179,7 @@ export class OYInternalError extends Error {
   /* Flow errors. */
 
   static userCanceled() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.userCanceled,
       exposedErrorType: OpenYoloErrorType.userCanceled,
       message: 'The user canceled the operation.'
@@ -188,7 +187,7 @@ export class OYInternalError extends Error {
   }
 
   static noCredentialsAvailable() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.noCredentialsAvailable,
       exposedErrorType: OpenYoloErrorType.noCredentialsAvailable,
       message: 'No credential is available for the current user.'
@@ -196,7 +195,7 @@ export class OYInternalError extends Error {
   }
 
   static operationCanceled() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.operationCanceled,
       exposedErrorType: OpenYoloErrorType.operationCanceled,
       message: 'The operation was canceled.'
@@ -204,7 +203,7 @@ export class OYInternalError extends Error {
   }
 
   static clientDisposed() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.clientDisposed,
       exposedErrorType: OpenYoloErrorType.clientDisposed,
       message: 'The API has been disposed from the current context.'
@@ -214,7 +213,7 @@ export class OYInternalError extends Error {
   /* Request errors. */
 
   static requestFailed(message: string) {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.requestFailed,
       exposedErrorType: OpenYoloErrorType.requestFailed,
       message: `The API request failed to resolve: ${message}`
@@ -222,7 +221,7 @@ export class OYInternalError extends Error {
   }
 
   static requestTimeout() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.requestTimeout,
       exposedErrorType: OpenYoloErrorType.requestFailed,
       message: 'The API request timed out.'
@@ -230,7 +229,7 @@ export class OYInternalError extends Error {
   }
 
   static illegalConcurrentRequestError() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.illegalConcurrentRequest,
       exposedErrorType: OpenYoloErrorType.illegalConcurrentRequest,
       message:
@@ -240,16 +239,16 @@ export class OYInternalError extends Error {
   }
 
   static unknownRequest(requestType: string) {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.unknownRequest,
       exposedErrorType: OpenYoloErrorType.requestFailed,
       message: `The '${requestType}' request sent could not be handled by the` +
-          `credentials provider.`
+          ` credentials provider.`
     });
   }
 
   static unknownError() {
-    return new OYInternalError({
+    return new OpenYoloInternalError({
       code: InternalErrorCode.unknownError,
       exposedErrorType: OpenYoloErrorType.unknownError,
       message: `Unkown error.`
@@ -285,11 +284,11 @@ export class OpenYoloError extends Error {
     this.name = 'OpenYoloError';
   }
 
-  toData(): OYExposedErrorData {
+  toData(): OpenYoloExposedErrorData {
     return {message: this.message, type: this.type};
   }
 
-  static fromData(data: OYExposedErrorData): OpenYoloError {
+  static fromData(data: OpenYoloExposedErrorData): OpenYoloError {
     return new OpenYoloError(data.message, data.type);
   }
 }

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -86,17 +86,17 @@ export class OYInternalError extends Error {
     super(data.message);
   }
 
+  /** Returns the client-side exposed error. */
+  toExposedError(): OpenYoloError {
+    return OpenYoloError.fromData(this.toExposedErrorData());
+  }
+
   /** Returns the client-side exposed error data. */
-  toExposedErrorData(): OYExposedErrorData {
+  private toExposedErrorData(): OYExposedErrorData {
     return {
       type: this.data.exposedErrorType,
       message: `${this.data.code}: ${this.data.message}`
     };
-  }
-
-  /** Returns the client-side exposed error. */
-  toExposedError(): OpenYoloError {
-    return OpenYoloError.fromData(this.toExposedErrorData());
   }
 
   /* Initialization errors. */
@@ -270,8 +270,6 @@ export class OYInternalError extends Error {
  * Client side exposed error type.
  */
 export declare interface OpenYoloError extends Error {
-  /** Name of the error, to differentiate from ‘Error’. */
-  name: string;  // = ‘OpenYoloError’.
   /** Standardized error type. */
   type: OpenYoloErrorType;
   /**

--- a/ts/protocol/post_messages.ts
+++ b/ts/protocol/post_messages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloError, OYExposedErrorData} from './errors';
+import {OpenYoloError, OpenYoloExposedErrorData} from './errors';
 import {DataValidator, isNonEmptyString, isValidError} from './validators';
 
 /**
@@ -51,7 +51,7 @@ export type PostMessageDataTypes = {
   'channelReady': string,
   'channelConnect': string,
   // Ensure only exposable data is sent through the message channel.
-  'channelError': OYExposedErrorData
+  'channelError': OpenYoloExposedErrorData
 };
 
 export type PostMessageData<T extends PostMessageType> =

--- a/ts/protocol/post_messages.ts
+++ b/ts/protocol/post_messages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYErrorData, OYInternalError} from './errors';
+import {OpenYoloError, OYExposedErrorData} from './errors';
 import {DataValidator, isNonEmptyString, isValidError} from './validators';
 
 /**
@@ -50,7 +50,8 @@ export type PostMessageDataTypes = {
   'verifyAck': string,
   'channelReady': string,
   'channelConnect': string,
-  'channelError': OYErrorData
+  // Ensure only exposable data is sent through the message channel.
+  'channelError': OYExposedErrorData
 };
 
 export type PostMessageData<T extends PostMessageType> =
@@ -93,8 +94,8 @@ export function channelReadyMessage(nonce: string) {
   return postMessage(PostMessageType.channelReady, nonce);
 }
 
-export function channelErrorMessage(error: OYInternalError) {
-  return postMessage(PostMessageType.channelError, error.data);
+export function channelErrorMessage(error: OpenYoloError) {
+  return postMessage(PostMessageType.channelError, error.toData());
 }
 
 export function readyForConnectMessage(nonce: string) {

--- a/ts/protocol/post_messages.ts
+++ b/ts/protocol/post_messages.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloErrorData, OpenYoloExtendedError} from './errors';
+import {OYErrorData, OYInternalError} from './errors';
 import {DataValidator, isNonEmptyString, isValidError} from './validators';
 
 /**
@@ -50,7 +50,7 @@ export type PostMessageDataTypes = {
   'verifyAck': string,
   'channelReady': string,
   'channelConnect': string,
-  'channelError': OpenYoloErrorData
+  'channelError': OYErrorData
 };
 
 export type PostMessageData<T extends PostMessageType> =
@@ -93,7 +93,7 @@ export function channelReadyMessage(nonce: string) {
   return postMessage(PostMessageType.channelReady, nonce);
 }
 
-export function channelErrorMessage(error: OpenYoloExtendedError) {
+export function channelErrorMessage(error: OYInternalError) {
   return postMessage(PostMessageType.channelError, error.data);
 }
 

--- a/ts/protocol/preload_request.ts
+++ b/ts/protocol/preload_request.ts
@@ -28,7 +28,7 @@
  * as part of the initial load of the iframe, to speed up handling of these
  * requests.
  */
-import {OYCredentialHintOptions, OYCredentialRequestOptions} from './data';
+import {OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from './data';
 
 
 export enum PreloadRequestType {
@@ -38,12 +38,12 @@ export enum PreloadRequestType {
 
 export interface HintPreloadRequest {
   type: PreloadRequestType;
-  options: OYCredentialHintOptions;
+  options: OpenYoloCredentialHintOptions;
 }
 
 export interface RetrievePreloadRequest {
   type: PreloadRequestType;
-  options: OYCredentialRequestOptions;
+  options: OpenYoloCredentialRequestOptions;
 }
 
 export type PreloadRequest = HintPreloadRequest | RetrievePreloadRequest;

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from './data';
-import {OpenYoloError, OYExposedErrorData} from './errors';
+import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from './data';
+import {OpenYoloError, OpenYoloExposedErrorData} from './errors';
 import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
 export enum RpcMessageType {
@@ -42,20 +42,20 @@ export enum RpcMessageType {
 export type RpcMessageArgumentTypes = {
   'disableAutoSignIn': undefined,
   'disableAutoSignInResult': undefined,
-  'retrieve': OYCredentialRequestOptions,
-  'hintAvailable': OYCredentialHintOptions,
+  'retrieve': OpenYoloCredentialRequestOptions,
+  'hintAvailable': OpenYoloCredentialHintOptions,
   'hintAvailableResult': boolean,
-  'hint': OYCredentialHintOptions,
-  'save': OYCredential,
+  'hint': OpenYoloCredentialHintOptions,
+  'save': OpenYoloCredential,
   'saveResult': boolean,
-  'proxy': OYCredential,
-  'proxyResult': OYProxyLoginResponse,
+  'proxy': OpenYoloCredential,
+  'proxyResult': OpenYoloProxyLoginResponse,
   'showProvider': DisplayOptions,
   'wrapBrowser': undefined,
   'wrapBrowserResult': boolean,
   'none': undefined,
-  'credential': OYCredential,
-  'error': OYExposedErrorData,
+  'credential': OpenYoloCredential,
+  'error': OpenYoloExposedErrorData,
   'cancelLastOperation': undefined,
   'cancelLastOperationResult': undefined
 };
@@ -128,12 +128,12 @@ export function disableAutoSignInResultMessage(id: string) {
 }
 
 export function retrieveMessage(
-    id: string, options: OYCredentialRequestOptions) {
+    id: string, options: OpenYoloCredentialRequestOptions) {
   return rpcMessage(RpcMessageType.retrieve, id, options);
 }
 
 export function hintAvailableMessage(
-    id: string, options: OYCredentialHintOptions) {
+    id: string, options: OpenYoloCredentialHintOptions) {
   return rpcMessage(RpcMessageType.hintAvailable, id, options);
 }
 
@@ -141,16 +141,17 @@ export function hintAvailableResponseMessage(id: string, available: boolean) {
   return rpcMessage(RpcMessageType.hintAvailableResult, id, available);
 }
 
-export function hintMessage(id: string, options: OYCredentialHintOptions) {
+export function hintMessage(
+    id: string, options: OpenYoloCredentialHintOptions) {
   return rpcMessage(RpcMessageType.hint, id, options);
 }
 
-export function proxyLoginMessage(id: string, credential: OYCredential) {
+export function proxyLoginMessage(id: string, credential: OpenYoloCredential) {
   return rpcMessage(RpcMessageType.proxy, id, credential);
 }
 
 export function proxyLoginResponseMessage(
-    id: string, response: OYProxyLoginResponse) {
+    id: string, response: OpenYoloProxyLoginResponse) {
   return rpcMessage(RpcMessageType.proxyResult, id, response);
 }
 
@@ -167,7 +168,8 @@ export function noneAvailableMessage(id: string) {
   return rpcMessage(RpcMessageType.none, id, undefined);
 }
 
-export function credentialResultMessage(id: string, credential: OYCredential) {
+export function credentialResultMessage(
+    id: string, credential: OpenYoloCredential) {
   return rpcMessage(RpcMessageType.credential, id, credential);
 }
 
@@ -175,7 +177,7 @@ export function showProviderMessage(id: string, options: DisplayOptions) {
   return rpcMessage(RpcMessageType.showProvider, id, options);
 }
 
-export function saveMessage(id: string, credential: OYCredential) {
+export function saveMessage(id: string, credential: OpenYoloCredential) {
   return rpcMessage(RpcMessageType.save, id, credential);
 }
 

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -15,7 +15,7 @@
  */
 
 import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from './data';
-import {OpenYoloErrorData, OpenYoloExtendedError} from './errors';
+import {OYErrorData, OYInternalError} from './errors';
 import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
 export enum RpcMessageType {
@@ -55,7 +55,7 @@ export type RpcMessageArgumentTypes = {
   'wrapBrowserResult': boolean,
   'none': undefined,
   'credential': OYCredential,
-  'error': OpenYoloErrorData,
+  'error': OYErrorData,
   'cancelLastOperation': undefined,
   'cancelLastOperationResult': undefined
 };
@@ -107,7 +107,7 @@ export const RPC_MESSAGE_DATA_VALIDATORS: RpcMessageDataValidators = {
 
 export interface CredentialResponseData { credential: OYCredential; }
 
-export interface ErrorMessageData { error: OpenYoloErrorData; }
+export interface ErrorMessageData { error: OYErrorData; }
 
 export interface DisplayOptions {
   height?: number;
@@ -187,7 +187,7 @@ export function saveResultMessage(id: string, saved: boolean) {
   return rpcMessage(RpcMessageType.saveResult, id, saved);
 }
 
-export function errorMessage(id: string, error: OpenYoloExtendedError) {
+export function errorMessage(id: string, error: OYInternalError) {
   return rpcMessage(RpcMessageType.error, id, error.data);
 }
 

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -15,7 +15,7 @@
  */
 
 import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions, OYProxyLoginResponse} from './data';
-import {OYErrorData, OYInternalError} from './errors';
+import {OpenYoloError, OYExposedErrorData} from './errors';
 import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
 export enum RpcMessageType {
@@ -55,7 +55,7 @@ export type RpcMessageArgumentTypes = {
   'wrapBrowserResult': boolean,
   'none': undefined,
   'credential': OYCredential,
-  'error': OYErrorData,
+  'error': OYExposedErrorData,
   'cancelLastOperation': undefined,
   'cancelLastOperationResult': undefined
 };
@@ -104,10 +104,6 @@ export const RPC_MESSAGE_DATA_VALIDATORS: RpcMessageDataValidators = {
   'cancelLastOperation': rpcDataValidator(isUndefined),
   'cancelLastOperationResult': rpcDataValidator(isUndefined)
 };
-
-export interface CredentialResponseData { credential: OYCredential; }
-
-export interface ErrorMessageData { error: OYErrorData; }
 
 export interface DisplayOptions {
   height?: number;
@@ -187,8 +183,8 @@ export function saveResultMessage(id: string, saved: boolean) {
   return rpcMessage(RpcMessageType.saveResult, id, saved);
 }
 
-export function errorMessage(id: string, error: OYInternalError) {
-  return rpcMessage(RpcMessageType.error, id, error.data);
+export function errorMessage(id: string, error: OpenYoloError) {
+  return rpcMessage(RpcMessageType.error, id, error.toData());
 }
 
 export function cancelLastOperationMessage(id: string) {

--- a/ts/protocol/secure_channel.ts
+++ b/ts/protocol/secure_channel.ts
@@ -15,7 +15,7 @@
  */
 
 import {createMessageListener, FilteringEventListener, isPermittedOrigin, RpcMessageListener, WindowLike} from './comms';
-import {OpenYoloError, OYInternalError} from './errors';
+import {OpenYoloError, OpenYoloInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, PostMessageType, readyForConnectMessage} from './post_messages';
 import {RpcMessage, RpcMessageData, RpcMessageType} from './rpc_messages';
 import {PromiseResolver, sha256, timeoutPromise} from './utils';
@@ -156,7 +156,8 @@ export class SecureChannel {
             SecureChannel.debugLog(
                 'provider',
                 'connection challenge from untrusted origin - rejecting');
-            promiseResolver.reject(OYInternalError.untrustedOrigin(ev.origin));
+            promiseResolver.reject(
+                OpenYoloInternalError.untrustedOrigin(ev.origin));
             return;
           }
 
@@ -164,7 +165,7 @@ export class SecureChannel {
             SecureChannel.debugLog(
                 'provider',
                 'connection challenge did not carry a port - rejecting');
-            promiseResolver.reject(OYInternalError.illegalStateError(
+            promiseResolver.reject(OpenYoloInternalError.illegalStateError(
                 'channel initialization message does not contain ports'));
             return;
           }
@@ -244,7 +245,7 @@ export class SecureChannel {
       }
     });
     const timeout = timeoutPromise<SecureChannel>(
-        OYInternalError.ackTimeout(), ACK_TIMEOUT_MS);
+        OpenYoloInternalError.ackTimeout(), ACK_TIMEOUT_MS);
     timeout.catch((err) => {
       this.port.removeEventListener('message', ackListner);
     });
@@ -258,7 +259,7 @@ export class SecureChannel {
       messageType: T,
       listener: RpcMessageListener<T>): number {
     if (!messageType || !listener) {
-      throw OYInternalError.illegalStateError('invalid type or listener');
+      throw OpenYoloInternalError.illegalStateError('invalid type or listener');
     }
 
     let portListener = createMessageListener(

--- a/ts/protocol/secure_channel.ts
+++ b/ts/protocol/secure_channel.ts
@@ -15,7 +15,7 @@
  */
 
 import {createMessageListener, FilteringEventListener, isPermittedOrigin, RpcMessageListener, WindowLike} from './comms';
-import {OYExposedError, OYInternalError} from './errors';
+import {OpenYoloError, OYInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, PostMessageType, readyForConnectMessage} from './post_messages';
 import {RpcMessage, RpcMessageData, RpcMessageType} from './rpc_messages';
 import {PromiseResolver, sha256, timeoutPromise} from './utils';
@@ -48,20 +48,20 @@ export class SecureChannel {
     await SecureChannel.providerReadyToConnect(
         clientWindow, connectionNonceHash);
 
-    let channel = new MessageChannel();
+    const channel = new MessageChannel();
 
-    let readyPromiseResolver = new PromiseResolver();
+    const readyPromiseResolver = new PromiseResolver();
     // register another listener for the success / fail of establishing the
     // connection.
 
-    let readyListener =
+    const readyListener =
         createMessageListener(PostMessageType.channelReady, () => {
           readyPromiseResolver.resolve();
         });
 
-    let errorListener =
+    const errorListener =
         createMessageListener(PostMessageType.channelError, (data) => {
-          readyPromiseResolver.reject(OYExposedError.fromData(data));
+          readyPromiseResolver.reject(OpenYoloError.fromData(data));
         });
 
     clientWindow.addEventListener('message', readyListener);

--- a/ts/protocol/secure_channel.ts
+++ b/ts/protocol/secure_channel.ts
@@ -15,12 +15,10 @@
  */
 
 import {createMessageListener, FilteringEventListener, isPermittedOrigin, RpcMessageListener, WindowLike} from './comms';
-import {OpenYoloError} from './errors';
+import {OYExposedError, OYInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, PostMessageType, readyForConnectMessage} from './post_messages';
 import {RpcMessage, RpcMessageData, RpcMessageType} from './rpc_messages';
 import {PromiseResolver, sha256, timeoutPromise} from './utils';
-
-const DEFAULT_TIMEOUT_MS = 3000;
 
 /**
  * The timeout for ack message.
@@ -39,28 +37,7 @@ export class SecureChannel {
   private listeners: Array<ListenerPair|null> = [];
   private fallbackListeners: UnknownMessageEventListener[] = [];
 
-  /**
-   * Connect method that an OpenYOLO client calls to establish contact with
-   * the provider.
-   */
-  static clientConnect(
-      clientWindow: WindowLike,
-      providerWindow: WindowLike,
-      connectionNonce: string,
-      connectionNonceHash: string,
-      timeoutMs?: number): Promise<SecureChannel> {
-    timeoutMs = (timeoutMs && timeoutMs > 0) ? timeoutMs : DEFAULT_TIMEOUT_MS;
-
-    let timeout = timeoutPromise<SecureChannel>(
-        OpenYoloError.establishSecureChannelTimeout(), timeoutMs);
-
-    let connectPromise = SecureChannel.clientConnectNoTimeout(
-        clientWindow, providerWindow, connectionNonce, connectionNonceHash);
-
-    return Promise.race([timeout, connectPromise]);
-  }
-
-  static async clientConnectNoTimeout(
+  static async clientConnect(
       clientWindow: WindowLike,
       providerWindow: WindowLike,
       connectionNonce: string,
@@ -83,8 +60,8 @@ export class SecureChannel {
         });
 
     let errorListener =
-        createMessageListener(PostMessageType.channelError, (err) => {
-          readyPromiseResolver.reject(OpenYoloError.createError(err));
+        createMessageListener(PostMessageType.channelError, (data) => {
+          readyPromiseResolver.reject(OYExposedError.fromData(data));
         });
 
     clientWindow.addEventListener('message', readyListener);
@@ -179,7 +156,7 @@ export class SecureChannel {
             SecureChannel.debugLog(
                 'provider',
                 'connection challenge from untrusted origin - rejecting');
-            promiseResolver.reject(OpenYoloError.untrustedOrigin(ev.origin));
+            promiseResolver.reject(OYInternalError.untrustedOrigin(ev.origin));
             return;
           }
 
@@ -187,7 +164,7 @@ export class SecureChannel {
             SecureChannel.debugLog(
                 'provider',
                 'connection challenge did not carry a port - rejecting');
-            promiseResolver.reject(OpenYoloError.illegalStateError(
+            promiseResolver.reject(OYInternalError.illegalStateError(
                 'channel initialization message does not contain ports'));
             return;
           }
@@ -267,7 +244,7 @@ export class SecureChannel {
       }
     });
     const timeout = timeoutPromise<SecureChannel>(
-        OpenYoloError.ackTimeout(), ACK_TIMEOUT_MS);
+        OYInternalError.ackTimeout(), ACK_TIMEOUT_MS);
     timeout.catch((err) => {
       this.port.removeEventListener('message', ackListner);
     });
@@ -281,7 +258,7 @@ export class SecureChannel {
       messageType: T,
       listener: RpcMessageListener<T>): number {
     if (!messageType || !listener) {
-      throw OpenYoloError.illegalStateError('invalid type or listener');
+      throw OYInternalError.illegalStateError('invalid type or listener');
     }
 
     let portListener = createMessageListener(

--- a/ts/protocol/secure_channel_test.ts
+++ b/ts/protocol/secure_channel_test.ts
@@ -19,7 +19,7 @@ import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent, createUntypedMessageEvent} from '../test_utils/messages';
 import {JasmineTimeoutManager} from '../test_utils/timeout';
 
-import {InternalErrorCode, OpenYoloError} from './errors';
+import {InternalErrorCode, OYInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, readyForConnectMessage} from './post_messages';
 import * as msg from './rpc_messages';
 import {SecureChannel} from './secure_channel';
@@ -70,32 +70,6 @@ describe('SecureChannel', () => {
       } catch (err) {
         done.fail('Promise should resolve');
       }
-    });
-
-    it('times out automatically if no response', (done) => {
-      let timeoutMs = 100;
-      let expectReject = false;
-      SecureChannel
-          .clientConnect(
-              clientWindow, providerWindow, '1234', 'hash', timeoutMs)
-          .then(
-              () => {
-                done.fail('Creation should not succeed!');
-              },
-              (err: Error) => {
-                expect(expectReject).toBeTruthy('Failed before timeout');
-                expect(
-                    OpenYoloError.errorIs(
-                        err, InternalErrorCode.establishSecureChannelTimeout))
-                    .toBeTruthy();
-                done();
-              });
-
-      // move the clock forward to just before the timeout
-      jasmine.clock().tick(99);
-      // then move the clock past it
-      expectReject = true;
-      jasmine.clock().tick(1);
     });
   });
 
@@ -169,7 +143,7 @@ describe('SecureChannel', () => {
             },
             (err) => {
               expect(expectReject).toBeTruthy('Failed before timeout');
-              expect(OpenYoloError.errorIs(err, InternalErrorCode.ackTimeout))
+              expect(OYInternalError.errorIs(err, InternalErrorCode.ackTimeout))
                   .toBeTruthy();
               expect(port.removeEventListener)
                   .toHaveBeenCalledWith('message', jasmine.any(Function));
@@ -264,7 +238,7 @@ describe('SecureChannel', () => {
         await connectPromise;
         done.fail('Promise should reject');
       } catch (err) {
-        expect(err).toEqual(OpenYoloError.untrustedOrigin(evilOrigin));
+        expect(err).toEqual(OYInternalError.untrustedOrigin(evilOrigin));
         done();
       }
     });

--- a/ts/protocol/secure_channel_test.ts
+++ b/ts/protocol/secure_channel_test.ts
@@ -19,7 +19,7 @@ import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent, createUntypedMessageEvent} from '../test_utils/messages';
 import {JasmineTimeoutManager} from '../test_utils/timeout';
 
-import {InternalErrorCode, OYInternalError} from './errors';
+import {InternalErrorCode, OpenYoloInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, readyForConnectMessage} from './post_messages';
 import * as msg from './rpc_messages';
 import {SecureChannel} from './secure_channel';
@@ -143,7 +143,8 @@ describe('SecureChannel', () => {
             },
             (err) => {
               expect(expectReject).toBeTruthy('Failed before timeout');
-              expect(OYInternalError.errorIs(err, InternalErrorCode.ackTimeout))
+              expect(OpenYoloInternalError.errorIs(
+                         err, InternalErrorCode.ackTimeout))
                   .toBeTruthy();
               expect(port.removeEventListener)
                   .toHaveBeenCalledWith('message', jasmine.any(Function));
@@ -238,7 +239,7 @@ describe('SecureChannel', () => {
         await connectPromise;
         done.fail('Promise should reject');
       } catch (err) {
-        expect(err).toEqual(OYInternalError.untrustedOrigin(evilOrigin));
+        expect(err).toEqual(OpenYoloInternalError.untrustedOrigin(evilOrigin));
         done();
       }
     });

--- a/ts/spi/ancestor_origin_verifier.ts
+++ b/ts/spi/ancestor_origin_verifier.ts
@@ -15,7 +15,7 @@
  */
 
 import {createMessageListener, isPermittedOrigin, sendMessage, WindowLike} from '../protocol/comms';
-import {OYInternalError} from '../protocol/errors';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {PostMessageType, verifyPingMessage} from '../protocol/post_messages';
 import {generateId, TimeoutPromiseResolver} from '../protocol/utils';
 
@@ -89,7 +89,7 @@ export class AncestorOriginVerifier {
     // Ensure the provider frame is running as a child frame or a popup.
     if (this.providerFrame.parent === this.providerFrame &&
         !this.providerFrame.opener) {
-      return Promise.reject(OYInternalError.illegalStateError(
+      return Promise.reject(OpenYoloInternalError.illegalStateError(
           'The request should be opened in an iframe or a popup'));
     }
 
@@ -102,7 +102,7 @@ export class AncestorOriginVerifier {
     }
 
     if (ancestorFrame.parent !== ancestorFrame && !allowMultipleAncestors) {
-      return Promise.reject(OYInternalError.parentIsNotRoot());
+      return Promise.reject(OpenYoloInternalError.parentIsNotRoot());
     }
 
     let promises: Array<Promise<string>> = [];
@@ -121,7 +121,7 @@ export class AncestorOriginVerifier {
   async verifyAncestorOrigin(ancestorFrame: WindowLike, parentDepth: number):
       Promise<string> {
     let promiseResolver = new TimeoutPromiseResolver<string>(
-        OYInternalError.parentVerifyTimeout(), this.timeoutMs);
+        OpenYoloInternalError.parentVerifyTimeout(), this.timeoutMs);
 
     let verifyId: string = generateId();
 
@@ -139,7 +139,8 @@ export class AncestorOriginVerifier {
             promiseResolver.resolve(ev.origin);
           } else {
             console.warn(`untrusted domain in ancestor chain: ${ev.origin}`);
-            promiseResolver.reject(OYInternalError.untrustedOrigin(ev.origin));
+            promiseResolver.reject(
+                OpenYoloInternalError.untrustedOrigin(ev.origin));
           }
         });
 

--- a/ts/spi/ancestor_origin_verifier.ts
+++ b/ts/spi/ancestor_origin_verifier.ts
@@ -15,7 +15,7 @@
  */
 
 import {createMessageListener, isPermittedOrigin, sendMessage, WindowLike} from '../protocol/comms';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {PostMessageType, verifyPingMessage} from '../protocol/post_messages';
 import {generateId, TimeoutPromiseResolver} from '../protocol/utils';
 
@@ -89,7 +89,7 @@ export class AncestorOriginVerifier {
     // Ensure the provider frame is running as a child frame or a popup.
     if (this.providerFrame.parent === this.providerFrame &&
         !this.providerFrame.opener) {
-      return Promise.reject(OpenYoloError.illegalStateError(
+      return Promise.reject(OYInternalError.illegalStateError(
           'The request should be opened in an iframe or a popup'));
     }
 
@@ -102,7 +102,7 @@ export class AncestorOriginVerifier {
     }
 
     if (ancestorFrame.parent !== ancestorFrame && !allowMultipleAncestors) {
-      return Promise.reject(OpenYoloError.parentIsNotRoot());
+      return Promise.reject(OYInternalError.parentIsNotRoot());
     }
 
     let promises: Array<Promise<string>> = [];
@@ -121,7 +121,7 @@ export class AncestorOriginVerifier {
   async verifyAncestorOrigin(ancestorFrame: WindowLike, parentDepth: number):
       Promise<string> {
     let promiseResolver = new TimeoutPromiseResolver<string>(
-        OpenYoloError.ancestorVerifyTimeout(), this.timeoutMs);
+        OYInternalError.parentVerifyTimeout(), this.timeoutMs);
 
     let verifyId: string = generateId();
 
@@ -139,7 +139,7 @@ export class AncestorOriginVerifier {
             promiseResolver.resolve(ev.origin);
           } else {
             console.warn(`untrusted domain in ancestor chain: ${ev.origin}`);
-            promiseResolver.reject(OpenYoloError.untrustedOrigin(ev.origin));
+            promiseResolver.reject(OYInternalError.untrustedOrigin(ev.origin));
           }
         });
 

--- a/ts/spi/ancestor_origin_verifier_test.ts
+++ b/ts/spi/ancestor_origin_verifier_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OYInternalError} from '../protocol/errors';
+import {OpenYoloInternalError} from '../protocol/errors';
 import {PostMessageType, verifyAckMessage, verifyPingMessage} from '../protocol/post_messages';
 import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent} from '../test_utils/messages';
@@ -75,7 +75,8 @@ describe('AncestorOriginVerifier', () => {
               },
               (err) => {
                 expect(expectFailNow).toBeTruthy('Failed too early');
-                expect(err).toEqual(OYInternalError.parentVerifyTimeout());
+                expect(err).toEqual(
+                    OpenYoloInternalError.parentVerifyTimeout());
                 done();
               });
 
@@ -120,7 +121,8 @@ describe('AncestorOriginVerifier', () => {
            done.fail('Verification should not succeed');
          } catch (err) {
            expect(pingReceived).toBeTruthy();
-           expect(err).toEqual(OYInternalError.untrustedOrigin(parentOrigin));
+           expect(err).toEqual(
+               OpenYoloInternalError.untrustedOrigin(parentOrigin));
            done();
          }
        });
@@ -145,7 +147,7 @@ describe('AncestorOriginVerifier', () => {
         await verifyPromise;
         done.fail('Verification should not succeed');
       } catch (err) {
-        expect(err).toEqual(OYInternalError.parentVerifyTimeout());
+        expect(err).toEqual(OpenYoloInternalError.parentVerifyTimeout());
         done();
       }
     });
@@ -167,7 +169,7 @@ describe('AncestorOriginVerifier', () => {
         await verifyPromise;
         done.fail('Verification should not succeed');
       } catch (err) {
-        expect(err).toEqual(OYInternalError.parentVerifyTimeout());
+        expect(err).toEqual(OpenYoloInternalError.parentVerifyTimeout());
         done();
       }
     });
@@ -196,7 +198,7 @@ describe('AncestorOriginVerifier', () => {
            done.fail('Verification should not succeed');
          } catch (err) {
            expect(pingReceived).toBeTruthy();
-           expect(err).toEqual(OYInternalError.parentVerifyTimeout());
+           expect(err).toEqual(OpenYoloInternalError.parentVerifyTimeout());
            done();
          }
        });
@@ -222,7 +224,8 @@ describe('AncestorOriginVerifier', () => {
       it('should reject the promise when the parent is invalid',
          async function(done) {
            let parentOrigin = 'https://www.3vil.com';
-           let expectedError = OYInternalError.untrustedOrigin(parentOrigin);
+           let expectedError =
+               OpenYoloInternalError.untrustedOrigin(parentOrigin);
            spyOn(verifier, 'verifyAncestorOrigin')
                .and.returnValue(Promise.reject(expectedError));
            try {
@@ -243,7 +246,7 @@ describe('AncestorOriginVerifier', () => {
              await verifier.verify(false);
              done.fail('Promise should not resolve');
            } catch (err) {
-             expect(err).toEqual(OYInternalError.parentIsNotRoot());
+             expect(err).toEqual(OpenYoloInternalError.parentIsNotRoot());
              done();
            }
          });
@@ -282,7 +285,7 @@ describe('AncestorOriginVerifier', () => {
       it('should reject the promise if any ancestor is invalid',
          async function(done) {
            let expectedError =
-               OYInternalError.untrustedOrigin('https://www.3vil.com');
+               OpenYoloInternalError.untrustedOrigin('https://www.3vil.com');
            spyOn(verifier, 'verifyAncestorOrigin')
                .and.callFake((ancestor: any) => {
                  if (ancestor === parentFrame) {

--- a/ts/spi/ancestor_origin_verifier_test.ts
+++ b/ts/spi/ancestor_origin_verifier_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {PostMessageType, verifyAckMessage, verifyPingMessage} from '../protocol/post_messages';
 import {MockWindow} from '../test_utils/frames';
 import {createMessageEvent} from '../test_utils/messages';
@@ -75,7 +75,7 @@ describe('AncestorOriginVerifier', () => {
               },
               (err) => {
                 expect(expectFailNow).toBeTruthy('Failed too early');
-                expect(err).toEqual(OpenYoloError.ancestorVerifyTimeout());
+                expect(err).toEqual(OYInternalError.parentVerifyTimeout());
                 done();
               });
 
@@ -120,7 +120,7 @@ describe('AncestorOriginVerifier', () => {
            done.fail('Verification should not succeed');
          } catch (err) {
            expect(pingReceived).toBeTruthy();
-           expect(err).toEqual(OpenYoloError.untrustedOrigin(parentOrigin));
+           expect(err).toEqual(OYInternalError.untrustedOrigin(parentOrigin));
            done();
          }
        });
@@ -145,7 +145,7 @@ describe('AncestorOriginVerifier', () => {
         await verifyPromise;
         done.fail('Verification should not succeed');
       } catch (err) {
-        expect(err).toEqual(OpenYoloError.ancestorVerifyTimeout());
+        expect(err).toEqual(OYInternalError.parentVerifyTimeout());
         done();
       }
     });
@@ -167,7 +167,7 @@ describe('AncestorOriginVerifier', () => {
         await verifyPromise;
         done.fail('Verification should not succeed');
       } catch (err) {
-        expect(err).toEqual(OpenYoloError.ancestorVerifyTimeout());
+        expect(err).toEqual(OYInternalError.parentVerifyTimeout());
         done();
       }
     });
@@ -196,7 +196,7 @@ describe('AncestorOriginVerifier', () => {
            done.fail('Verification should not succeed');
          } catch (err) {
            expect(pingReceived).toBeTruthy();
-           expect(err).toEqual(OpenYoloError.ancestorVerifyTimeout());
+           expect(err).toEqual(OYInternalError.parentVerifyTimeout());
            done();
          }
        });
@@ -222,7 +222,7 @@ describe('AncestorOriginVerifier', () => {
       it('should reject the promise when the parent is invalid',
          async function(done) {
            let parentOrigin = 'https://www.3vil.com';
-           let expectedError = OpenYoloError.untrustedOrigin(parentOrigin);
+           let expectedError = OYInternalError.untrustedOrigin(parentOrigin);
            spyOn(verifier, 'verifyAncestorOrigin')
                .and.returnValue(Promise.reject(expectedError));
            try {
@@ -243,7 +243,7 @@ describe('AncestorOriginVerifier', () => {
              await verifier.verify(false);
              done.fail('Promise should not resolve');
            } catch (err) {
-             expect(err).toEqual(OpenYoloError.parentIsNotRoot());
+             expect(err).toEqual(OYInternalError.parentIsNotRoot());
              done();
            }
          });
@@ -282,7 +282,7 @@ describe('AncestorOriginVerifier', () => {
       it('should reject the promise if any ancestor is invalid',
          async function(done) {
            let expectedError =
-               OpenYoloError.untrustedOrigin('https://www.3vil.com');
+               OYInternalError.untrustedOrigin('https://www.3vil.com');
            spyOn(verifier, 'verifyAncestorOrigin')
                .and.callFake((ancestor: any) => {
                  if (ancestor === parentFrame) {

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -15,7 +15,7 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions} from '../protocol/data';
+import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {DisplayOptions} from '../protocol/rpc_messages';
 
 /**
@@ -102,27 +102,30 @@ export interface CredentialDataProvider {
   /**
    * Retrieves all hint credentials, based upon the provided options.
    */
-  getAllHints(options: OYCredentialHintOptions): Promise<OYCredential[]>;
+  getAllHints(options: OpenYoloCredentialHintOptions):
+      Promise<OpenYoloCredential[]>;
 
   /**
    * Retrieves all credentials for the specified authentication domains
    * (derived from the request) and the specified request options.
    */
-  getAllCredentials(authDomains: string[], options: OYCredentialRequestOptions):
-      Promise<OYCredential[]>;
+  getAllCredentials(
+      authDomains: string[],
+      options: OpenYoloCredentialRequestOptions): Promise<OpenYoloCredential[]>;
 
   /**
    * Creates or updates an existing credential. If the credential cannot be
    * created or updated, the promise should be rejected.
    */
-  upsertCredential(credential: OYCredential, original?: OYCredential):
-      Promise<OYCredential>;
+  upsertCredential(
+      credential: OpenYoloCredential,
+      original?: OpenYoloCredential): Promise<OpenYoloCredential>;
 
   /**
    * Deletes the provided credential from the store. If delete is not
    * permitted for this credential, the returned promise will be rejected.
    */
-  deleteCredential(credential: OYCredential): Promise<void>;
+  deleteCredential(credential: OpenYoloCredential): Promise<void>;
 }
 
 export interface DisplayCallbacks {
@@ -139,9 +142,9 @@ export interface InteractionProvider {
    * or reject if the action is cancelled or fails for any reason.
    */
   showCredentialPicker(
-      credentials: OYCredential[],
-      options: OYCredentialRequestOptions,
-      displayCallbacks: DisplayCallbacks): Promise<OYCredential>;
+      credentials: OpenYoloCredential[],
+      options: OpenYoloCredentialRequestOptions,
+      displayCallbacks: DisplayCallbacks): Promise<OpenYoloCredential>;
 
   /**
    * Requests the display of a hint picker containing the provided list of
@@ -150,9 +153,9 @@ export interface InteractionProvider {
    * not select a credential, the promise should be rejected.
    */
   showHintPicker(
-      hints: OYCredential[],
-      options: OYCredentialHintOptions,
-      displayCallbacks: DisplayCallbacks): Promise<OYCredential>;
+      hints: OpenYoloCredential[],
+      options: OpenYoloCredentialHintOptions,
+      displayCallbacks: DisplayCallbacks): Promise<OpenYoloCredential>;
 
   /**
    * Requests the display of a confirmation screen, allowing the user to
@@ -161,15 +164,16 @@ export interface InteractionProvider {
    * credential, false otherwise.
    */
   showSaveConfirmation(
-      credential: OYCredential,
+      credential: OpenYoloCredential,
       displayCallbacks: DisplayCallbacks): Promise<boolean>;
 
   /**
    * Requests the display of an auto sign in screen. The promise should always
    * resolve, as no action is required.
    */
-  showAutoSignIn(credential: OYCredential, displayCallbacks: DisplayCallbacks):
-      Promise<any>;
+  showAutoSignIn(
+      credential: OpenYoloCredential,
+      displayCallbacks: DisplayCallbacks): Promise<any>;
 
   /**
    * Requests the immediate tear down of any presently active UI.
@@ -205,8 +209,9 @@ export interface LocalStateProvider {
    * timescale equivalent to what sessionStorage provides - not permanent, but
    * able to survive page turns / reinstantiation of the provider frame.
    */
-  retainCredentialForSession(authDomain: string, credential: OYCredential):
-      Promise<void>;
+  retainCredentialForSession(
+      authDomain: string,
+      credential: OpenYoloCredential): Promise<void>;
 
   /**
    * Retrieves a retained credential for the specified authentication domain
@@ -218,5 +223,5 @@ export interface LocalStateProvider {
    * of this interface, such that subsequent calls to this method for the same
    * domain would also return a rejected promise.
    */
-  getRetainedCredential(authDomain: string): Promise<OYCredential>;
+  getRetainedCredential(authDomain: string): Promise<OpenYoloCredential>;
 }

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -17,7 +17,7 @@
 import {PrimaryClientConfiguration} from '../protocol/client_config';
 import {sendMessage} from '../protocol/comms';
 import {AUTHENTICATION_METHODS, OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions} from '../protocol/data';
-import {OpenYoloError} from '../protocol/errors';
+import {OYInternalError} from '../protocol/errors';
 import {isOpenYoloMessageFormat} from '../protocol/messages';
 import {channelErrorMessage} from '../protocol/post_messages';
 import * as msg from '../protocol/rpc_messages';
@@ -56,7 +56,7 @@ export class ProviderFrame {
               providerConfig.clientAuthDomain);
       if (!clientConfiguration || !clientConfiguration.apiEnabled) {
         console.info('OpenYOLO API is not enabled for the client origin');
-        throw OpenYoloError.apiDisabled();
+        throw OYInternalError.apiDisabled();
       }
 
       // Verify the ancestor frame(s), based on the client configuration and
@@ -101,7 +101,7 @@ export class ProviderFrame {
       // information, and that would be useful to the client.
       sendMessage(
           providerConfig.window.parent,
-          channelErrorMessage(OpenYoloError.providerInitFailed()));
+          channelErrorMessage(OYInternalError.providerInitializationFailed()));
 
       throw err;
     }
@@ -140,7 +140,7 @@ export class ProviderFrame {
   private async handleClose() {
     sendMessage(
         this.providerConfig.window.parent,
-        channelErrorMessage(OpenYoloError.canceled()));
+        channelErrorMessage(OYInternalError.userCanceled()));
   }
 
   private registerListeners() {
@@ -206,7 +206,7 @@ export class ProviderFrame {
         // reset cancellable promise, for the next set of requests
         this.cancellable = null;
         this.clientChannel.send(
-            msg.errorMessage(m.id, OpenYoloError.clientCancelled()));
+            msg.errorMessage(m.id, OYInternalError.operationCanceled()));
       } else {
         throw error;
       }
@@ -231,7 +231,7 @@ export class ProviderFrame {
 
     console.error(`Concurrent request ${requestId} received, rejecting`);
     this.clientChannel.send(msg.errorMessage(
-        requestId, OpenYoloError.illegalConcurrentRequestError()));
+        requestId, OYInternalError.illegalConcurrentRequestError()));
     return false;
   }
 
@@ -408,7 +408,7 @@ export class ProviderFrame {
   private async handleUnimplementedRequest(id: string, type: string) {
     console.error(`No implementation for request of type ${type}`);
     this.clientChannel.send(
-        msg.errorMessage(id, OpenYoloError.unknownRequest(type)));
+        msg.errorMessage(id, OYInternalError.unknownRequest(type)));
   }
 
   private handleUnknownMessage(ev: MessageEvent) {
@@ -438,7 +438,7 @@ export class ProviderFrame {
     // the message is a known, valid, but unhandled RPC message. Send a generic
     // failure message back.
     this.clientChannel.send(
-        msg.errorMessage(data.id, OpenYoloError.unknownRequest(type)));
+        msg.errorMessage(data.id, OYInternalError.unknownRequest(type)));
     return;
   }
 

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -238,8 +238,9 @@ describe('ProviderFrame', () => {
             data,
             msg.errorMessage(
                 requestId,
-                OYInternalError.unknownRequest(
-                    msg.RpcMessageType.hintAvailableResult)));
+                OYInternalError
+                    .unknownRequest(msg.RpcMessageType.hintAvailableResult)
+                    .toExposedError()));
         done();
       });
 
@@ -252,7 +253,9 @@ describe('ProviderFrame', () => {
         expectMessageContents(
             data,
             msg.errorMessage(
-                requestId, OYInternalError.illegalConcurrentRequestError()));
+                requestId,
+                OYInternalError.illegalConcurrentRequestError()
+                    .toExposedError()));
         done();
       });
 
@@ -349,7 +352,9 @@ describe('ProviderFrame', () => {
         clientChannel.listen(msg.RpcMessageType.error, (data) => {
           expectMessageContents(
               data,
-              msg.errorMessage(requestId, OYInternalError.operationCanceled()));
+              msg.errorMessage(
+                  requestId,
+                  OYInternalError.operationCanceled().toExposedError()));
           errorPromise.resolve();
         });
 

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -15,8 +15,8 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {AUTHENTICATION_METHODS, OYCredential, OYCredentialHintOptions, OYCredentialRequestOptions} from '../protocol/data';
-import {OYInternalError} from '../protocol/errors';
+import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from '../protocol/data';
+import {OpenYoloInternalError} from '../protocol/errors';
 import * as msg from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {PromiseResolver} from '../protocol/utils';
@@ -46,11 +46,11 @@ describe('ProviderFrame', () => {
 
   let frameConfig: ProviderConfiguration;
 
-  let alicePwdCred: OYCredential;
-  let bobPwdCred: OYCredential;
-  let carlGoogCred: OYCredential;
-  let deliaFbCred: OYCredential;
-  let elisaOtherDomainCred: OYCredential;
+  let alicePwdCred: OpenYoloCredential;
+  let bobPwdCred: OpenYoloCredential;
+  let carlGoogCred: OpenYoloCredential;
+  let deliaFbCred: OpenYoloCredential;
+  let elisaOtherDomainCred: OpenYoloCredential;
 
   let timeoutManager = new JasmineTimeoutManager();
 
@@ -146,7 +146,7 @@ describe('ProviderFrame', () => {
     });
 
     it('should fail if secure channel connection fails', async function(done) {
-      let expectedError = OYInternalError.establishSecureChannelTimeout();
+      let expectedError = OpenYoloInternalError.establishSecureChannelTimeout();
 
       spyOn(AncestorOriginVerifier, 'verifyOnlyParent')
           .and.returnValue(Promise.resolve(TEST_AUTH_DOMAIN));
@@ -179,7 +179,7 @@ describe('ProviderFrame', () => {
         await initPromise;
         done.fail('Initialization should not succeed');
       } catch (err) {
-        expect(err).toEqual(OYInternalError.apiDisabled());
+        expect(err).toEqual(OpenYoloInternalError.apiDisabled());
         done();
       }
     });
@@ -187,8 +187,8 @@ describe('ProviderFrame', () => {
     it('should fail if the parent origin is invalid', () => {
       let parentOrigin = 'https://www.3vil.com';
       spyOn(AncestorOriginVerifier, 'verifyOnlyParent')
-          .and.returnValue(
-              Promise.reject(OYInternalError.untrustedOrigin(parentOrigin)));
+          .and.returnValue(Promise.reject(
+              OpenYoloInternalError.untrustedOrigin(parentOrigin)));
       clientConfigurationProvider.configMap[TEST_AUTH_DOMAIN] = {
         type: 'primary',
         apiEnabled: true
@@ -238,7 +238,7 @@ describe('ProviderFrame', () => {
             data,
             msg.errorMessage(
                 requestId,
-                OYInternalError
+                OpenYoloInternalError
                     .unknownRequest(msg.RpcMessageType.hintAvailableResult)
                     .toExposedError()));
         done();
@@ -254,7 +254,7 @@ describe('ProviderFrame', () => {
             data,
             msg.errorMessage(
                 requestId,
-                OYInternalError.illegalConcurrentRequestError()
+                OpenYoloInternalError.illegalConcurrentRequestError()
                     .toExposedError()));
         done();
       });
@@ -286,7 +286,7 @@ describe('ProviderFrame', () => {
 
     describe('handling credential retrieval', () => {
 
-      let passwordOnlyRequest: OYCredentialRequestOptions = {
+      let passwordOnlyRequest: OpenYoloCredentialRequestOptions = {
         supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
       };
 
@@ -304,7 +304,7 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showAutoSignIn as jasmine.Spy)
                .and.callFake(
-                   (credential: OYCredential,
+                   (credential: OpenYoloCredential,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credential).toBe(alicePwdCred);
                      return Promise.resolve();
@@ -325,7 +325,7 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showAutoSignIn as jasmine.Spy)
             .and.callFake(
-                (credential: OYCredential,
+                (credential: OpenYoloCredential,
                  displayCallbacks: DisplayCallbacks) => {
                   expect(credential).toBe(alicePwdCred);
                   // return a promise that's not going to resolve
@@ -354,7 +354,7 @@ describe('ProviderFrame', () => {
               data,
               msg.errorMessage(
                   requestId,
-                  OYInternalError.operationCanceled().toExposedError()));
+                  OpenYoloInternalError.operationCanceled().toExposedError()));
           errorPromise.resolve();
         });
 
@@ -386,8 +386,8 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: OYCredential[],
-                    options: OYCredentialRequestOptions,
+                   (credentials: OpenYoloCredential[],
+                    options: OpenYoloCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credentials).toEqual([alicePwdCred]);
                      expect(options).toBeDefined();
@@ -423,8 +423,8 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showCredentialPicker as jasmine.Spy)
             .and.callFake(
-                (credentials: OYCredential[],
-                 options: OYCredentialRequestOptions,
+                (credentials: OpenYoloCredential[],
+                 options: OpenYoloCredentialRequestOptions,
                  displayCallbacks: DisplayCallbacks) => {
                   displayCallbacks.requestDisplayOptions(uiConfig).then(done);
                 });
@@ -441,8 +441,8 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: OYCredential[],
-                    options: OYCredentialRequestOptions,
+                   (credentials: OpenYoloCredential[],
+                    options: OpenYoloCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expect(credentials).toEqual([alicePwdCred, bobPwdCred]);
                      expect(options).toBeDefined();
@@ -471,11 +471,12 @@ describe('ProviderFrame', () => {
 
            (interactionProvider.showCredentialPicker as jasmine.Spy)
                .and.callFake(
-                   (credentials: OYCredential[],
-                    options: OYCredentialRequestOptions,
+                   (credentials: OpenYoloCredential[],
+                    options: OpenYoloCredentialRequestOptions,
                     displayCallbacks: DisplayCallbacks) => {
                      expectFinalResult = true;
-                     return Promise.reject(OYInternalError.userCanceled());
+                     return Promise.reject(
+                         OpenYoloInternalError.userCanceled());
                    });
 
            clientChannel.listen(msg.RpcMessageType.none, (data) => {
@@ -532,7 +533,7 @@ describe('ProviderFrame', () => {
     });
 
     // tests can use this to emulate user interaction in the credential picker
-    const pwdOrFbHintOptions: OYCredentialHintOptions = {
+    const pwdOrFbHintOptions: OpenYoloCredentialHintOptions = {
       supportedAuthMethods: [
         AUTHENTICATION_METHODS.ID_AND_PASSWORD,
         AUTHENTICATION_METHODS.FACEBOOK
@@ -592,8 +593,8 @@ describe('ProviderFrame', () => {
       // this is checked for as a follow-up message, otherwise a pick cancel
       // message is expected.
       function expectPickFromHints(
-          expectedHints: OYCredential[],
-          selection: OYCredential|null,
+          expectedHints: OpenYoloCredential[],
+          selection: OpenYoloCredential|null,
           expectedResult: msg.RpcMessage<msg.RpcMessageType.credential>|
           msg.RpcMessage<msg.RpcMessageType.none>,
           neverResolve: boolean = false) {
@@ -602,8 +603,8 @@ describe('ProviderFrame', () => {
 
         (interactionProvider.showHintPicker as jasmine.Spy)
             .and.callFake(
-                (hints: OYCredential[],
-                 options: OYCredentialHintOptions,
+                (hints: OpenYoloCredential[],
+                 options: OpenYoloCredentialHintOptions,
                  displayCallbacks: DisplayCallbacks) => {
                   expect(hints).toEqual(expectedHints);
                   expect(options).toBeDefined();
@@ -617,7 +618,8 @@ describe('ProviderFrame', () => {
                     if (selection) {
                       return Promise.resolve(selection);
                     } else {
-                      return Promise.reject(OYInternalError.userCanceled());
+                      return Promise.reject(
+                          OpenYoloInternalError.userCanceled());
                     }
                   }
                 });
@@ -671,7 +673,7 @@ describe('ProviderFrame', () => {
 
       it('should return selected hint', async function(done) {
         credentialDataProvider.credentials = [elisaOtherDomainCred];
-        let redactedElisaCred: OYCredential = {
+        let redactedElisaCred: OpenYoloCredential = {
           id: elisaOtherDomainCred.id,
           authMethod: elisaOtherDomainCred.authMethod,
           authDomain: TEST_AUTH_DOMAIN
@@ -740,7 +742,7 @@ describe('ProviderFrame', () => {
          });
 
       it('should prioritize hints with a display name', async function(done) {
-        let deliaFbCredWithName: OYCredential = {
+        let deliaFbCredWithName: OpenYoloCredential = {
           id: deliaFbCred.id,
           authMethod: deliaFbCred.authMethod,
           authDomain: deliaFbCred.authDomain,
@@ -756,7 +758,7 @@ describe('ProviderFrame', () => {
 
       it('should prioritize hints with a profile picture',
          async function(done) {
-           let deliaFbCredWithPicture: OYCredential = {
+           let deliaFbCredWithPicture: OpenYoloCredential = {
              id: deliaFbCred.id,
              authMethod: deliaFbCred.authMethod,
              authDomain: deliaFbCred.authDomain,
@@ -825,15 +827,16 @@ class TestClientConfigurationProvider implements ClientConfigurationProvider {
 }
 
 class TestCredentialDataProvider implements CredentialDataProvider {
-  credentials: OYCredential[] = [];
+  credentials: OpenYoloCredential[] = [];
   neverSave: {[key: string]: boolean} = {};
 
-  async getAllCredentials(authDomains: string[]): Promise<OYCredential[]> {
+  async getAllCredentials(authDomains: string[]):
+      Promise<OpenYoloCredential[]> {
     if (authDomains.length < 1) {
       return this.credentials;
     }
 
-    let filteredCredentials: OYCredential[] = [];
+    let filteredCredentials: OpenYoloCredential[] = [];
 
     for (let i = 0; i < this.credentials.length; i++) {
       let credential = this.credentials[i];
@@ -846,7 +849,8 @@ class TestCredentialDataProvider implements CredentialDataProvider {
     return filteredCredentials;
   }
 
-  async getAllHints(options: OYCredentialHintOptions): Promise<OYCredential[]> {
+  async getAllHints(options: OpenYoloCredentialHintOptions):
+      Promise<OpenYoloCredential[]> {
     // no filtering required in the hints case
     return this.credentials;
   }
@@ -874,15 +878,16 @@ class TestCredentialDataProvider implements CredentialDataProvider {
   /**
    * Determines whether the provided credential can be saved to this store.
    */
-  async canSave(credential: OYCredential): Promise<boolean> {
+  async canSave(credential: OpenYoloCredential): Promise<boolean> {
     return true;
   }
 
   /**
    * Creates or updates an existing credential.
    */
-  async upsertCredential(credential: OYCredential, original?: OYCredential):
-      Promise<OYCredential> {
+  async upsertCredential(
+      credential: OpenYoloCredential,
+      original?: OpenYoloCredential): Promise<OpenYoloCredential> {
     if (original) {
       await this.deleteCredential(original);
     }
@@ -893,7 +898,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
   /**
    * Determines whether the provided credential can be deleted.
    */
-  async canDelete(credential: OYCredential): Promise<boolean> {
+  async canDelete(credential: OpenYoloCredential): Promise<boolean> {
     return true;
   }
 
@@ -901,7 +906,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
    * Deletes the provided credential from the store. If delete is not
    * permitted for this credential, the returned promise will be rejected.
    */
-  async deleteCredential(credential: OYCredential): Promise<void> {
+  async deleteCredential(credential: OpenYoloCredential): Promise<void> {
     let existing = this.credentials.findIndex(
         (c) => c.authDomain === credential.authDomain &&
             c.id === credential.id && c.authMethod === credential.authMethod);
@@ -916,7 +921,7 @@ class TestCredentialDataProvider implements CredentialDataProvider {
 
 class TestLocalStateProvider implements LocalStateProvider {
   autoSignIn: {[label: string]: boolean} = {};
-  retained: {[authDomain: string]: OYCredential} = {};
+  retained: {[authDomain: string]: OpenYoloCredential} = {};
 
   async isAutoSignInEnabled(authDomain: string): Promise<boolean> {
     let result: boolean;
@@ -935,11 +940,11 @@ class TestLocalStateProvider implements LocalStateProvider {
 
   async retainCredentialForSession(
       authDomain: string,
-      credential: OYCredential) {
+      credential: OpenYoloCredential) {
     this.retained[authDomain] = credential;
   }
 
-  async getRetainedCredential(authDomain: string): Promise<OYCredential> {
+  async getRetainedCredential(authDomain: string): Promise<OpenYoloCredential> {
     if (this.retained[authDomain]) {
       let credential = this.retained[authDomain];
       delete this.retained[authDomain];


### PR DESCRIPTION
The new error codes have been added, and only OpenYoloError are now exposed and sent to the client side of the library.

Also renamed all variables prefixed by OY to use OpenYolo as prefix for consistency.