### PR TITLE
Fixed compilation issues

### DIFF
--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -166,11 +166,15 @@ const DEFAULT_TIMEOUTS: {[key in OpenYoloApiMethods]: number} = {
   cancelLastOperation: 3000
 };
 
+// This is a hack to be able to list the values of a "const enum"
+const RENDER_MODES: RenderMode[] =
+    [RenderMode.bottomSheet, RenderMode.navPopout, RenderMode.fullScreen];
+
 /**
  * Sanitzes the input for renderMode, selecting the default one if invalid.
  */
 function verifyOrDetectRenderMode(renderMode: RenderMode|null): RenderMode {
-  if (renderMode && renderMode in RenderMode) {
+  if (renderMode && RENDER_MODES.indexOf(renderMode) !== -1) {
     return renderMode;
   }
   const isNested = window.parent !== window;

--- a/ts/protocol/comms_test.ts
+++ b/ts/protocol/comms_test.ts
@@ -52,7 +52,7 @@ describe('comms', () => {
   });
 
   describe('createMessageListener', () => {
-    let spy: PostMessageListener<typeof PostMessageType.verifyPing>;
+    let spy: PostMessageListener<PostMessageType.verifyPing>;
     let listener: EventListener;
 
     beforeEach(() => {

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -189,8 +189,21 @@ export interface OpenYoloCredentialHintOptions {
  *
  * - navPopout: The provider is rendered in a pop-up style at the top of the
  *   screen, with a fixed width. The
+ *
+ * A const enum is required as string enums in TypeScript get compiled with
+ * properties in quotes. For instance, the following RenderMode would be:
+ *
+ * RenderMode = {
+ *   'bottomSheet': 'bottomSheet',
+ *   'navPopout': 'navPopout',
+ *   'fullScreen': 'fullScreen'
+ * }
+ *
+ * The issue is that the references to this enum are made WITHOUT bracket
+ * notations, so the Closure Compiler does not link the reference to the
+ * definition.
  */
-export enum RenderMode {
+export const enum RenderMode {
   bottomSheet = 'bottomSheet',
   navPopout = 'navPopout',
   fullScreen = 'fullScreen'

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -15,7 +15,7 @@
  */
 
 /* Internal, detailed, error codes. */
-export enum InternalErrorCode {
+export const enum InternalErrorCode {
   ackTimeout = 'ackTimeout',
   establishSecureChannelTimeout = 'establishSecureChannelTimeout',
   parentVerifyTimeout = 'parentVerifyTimeout',
@@ -36,7 +36,7 @@ export enum InternalErrorCode {
 }
 
 /* Exposed error types meant for apps to trigger different flows. */
-export enum OpenYoloErrorType {
+export const enum OpenYoloErrorType {
   initializationError = 'initializationError',
   configurationError = 'configurationError',
   userCanceled = 'userCanceled',
@@ -79,11 +79,26 @@ export interface OpenYoloExposedErrorData {
 }
 
 /**
+ * It is not possible to subclass Error, Array, Map... in TS anymore. It is
+ * recommended to create our own Error classes.
+ * https://github.com/Microsoft/TypeScript/issues/13965
+ */
+export interface CustomError {
+  /** Name of the error. */
+  name: string;
+  /** Message of the error. */
+  message: string;
+}
+
+/**
  * Internal error.
  */
-export class OpenYoloInternalError extends Error {
+export class OpenYoloInternalError implements CustomError {
+  name = 'OpenYoloInternalError';
+  message: string;
+
   constructor(public data: OpenYoloErrorData) {
-    super(data.message);
+    this.message = data.message;
   }
 
   /** Returns the client-side exposed error. */
@@ -268,7 +283,7 @@ export class OpenYoloInternalError extends Error {
 /**
  * Client side exposed error type.
  */
-export declare interface OpenYoloError extends Error {
+export declare interface OpenYoloError extends CustomError {
   /** Standardized error type. */
   type: OpenYoloErrorType;
   /**
@@ -278,10 +293,12 @@ export declare interface OpenYoloError extends Error {
   message: string;
 }
 
-export class OpenYoloError extends Error {
+export class OpenYoloError {
+  name = 'OpenYoloError';
+  message: string;
+
   constructor(message: string, public type: OpenYoloErrorType) {
-    super(message);
-    this.name = 'OpenYoloError';
+    this.message = message;
   }
 
   toData(): OpenYoloExposedErrorData {

--- a/ts/protocol/post_messages.ts
+++ b/ts/protocol/post_messages.ts
@@ -30,7 +30,7 @@ import {DataValidator, isNonEmptyString, isValidError} from './validators';
  *     indicate it is ready to accept requests.
  * - channelError: sent when establishing the message channel fails.
  */
-export enum PostMessageType {
+export const enum PostMessageType {
   ack = 'ack',
   verifyPing = 'verifyPing',
   verifyAck = 'verifyAck',

--- a/ts/protocol/preload_request.ts
+++ b/ts/protocol/preload_request.ts
@@ -31,10 +31,7 @@
 import {OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from './data';
 
 
-export enum PreloadRequestType {
-  hint = 'hint',
-  retrieve = 'retrieve'
-}
+export const enum PreloadRequestType {hint = 'hint', retrieve = 'retrieve'}
 
 export interface HintPreloadRequest {
   type: PreloadRequestType;

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -39,7 +39,7 @@ export const enum RpcMessageType {
   cancelLastOperationResult = 'cancelLastOperationResult'
 }
 
-// Hack to be able to sue the list of values of the const enum above.
+// Hack to be able to use the list of values of the const enum above.
 export const RPC_MESSAGE_TYPES: RpcMessageType[] = [
   RpcMessageType.disableAutoSignIn,
   RpcMessageType.disableAutoSignInResult,

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -18,7 +18,7 @@ import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialReq
 import {OpenYoloError, OpenYoloExposedErrorData} from './errors';
 import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
-export enum RpcMessageType {
+export const enum RpcMessageType {
   disableAutoSignIn = 'disableAutoSignIn',
   disableAutoSignInResult = 'disableAutoSignInResult',
   retrieve = 'retrieve',
@@ -38,6 +38,28 @@ export enum RpcMessageType {
   cancelLastOperation = 'cancelLastOperation',
   cancelLastOperationResult = 'cancelLastOperationResult'
 }
+
+// Hack to be able to sue the list of values of the const enum above.
+export const RPC_MESSAGE_TYPES: RpcMessageType[] = [
+  RpcMessageType.disableAutoSignIn,
+  RpcMessageType.disableAutoSignInResult,
+  RpcMessageType.retrieve,
+  RpcMessageType.hintAvailable,
+  RpcMessageType.hintAvailableResult,
+  RpcMessageType.hint,
+  RpcMessageType.save,
+  RpcMessageType.saveResult,
+  RpcMessageType.proxy,
+  RpcMessageType.proxyResult,
+  RpcMessageType.wrapBrowser,
+  RpcMessageType.wrapBrowserResult,
+  RpcMessageType.showProvider,
+  RpcMessageType.none,
+  RpcMessageType.credential,
+  RpcMessageType.error,
+  RpcMessageType.cancelLastOperation,
+  RpcMessageType.cancelLastOperationResult
+];
 
 export type RpcMessageArgumentTypes = {
   'disableAutoSignIn': undefined,

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -93,7 +93,7 @@ export class ProviderFrame {
     } catch (err) {
       // initialization failed, be courteous and notify the client as this
       // may not actually be their fault.
-      if (typeof err.toExposedError === 'function') {
+      if (err instanceof OpenYoloInternalError) {
         sendMessage(
             providerConfig.window.parent,
             channelErrorMessage(err.toExposedError()));
@@ -437,8 +437,8 @@ export class ProviderFrame {
           ev);
       return;
     }
-
-    if (!(ev.data.type in msg.RpcMessageType)) {
+    console.log(msg.RPC_MESSAGE_TYPES, ev.data.type);
+    if (msg.RPC_MESSAGE_TYPES.indexOf(ev.data.type) === -1) {
       console.warn('Non-RPC message received on secure channel, ignoring');
       return;
     }


### PR DESCRIPTION
1. TS 2.4 String enums compile in a format that makes it incompatible with Closure Compiler.

enum StrEnum {
  value = 'value';
  otherValue = 'otherValue'
}

Usage:
StrEnum.value

Will compile in:

StrEnum = {
  'value': 'value',
  'otherValue': 'otherValue'
}

StrEnum.value;

Notice quoted properties. This breaks obfuscation.

2. Error subclassing does not extend the prototype, so the `toExposedError` method wasn't available. https://github.com/Microsoft/TypeScript/issues/13965