### PR TITLE
Disable navigator.credentials fallback when not on https.

### DIFF
--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -193,8 +193,9 @@ export class OpenYoloApiImpl implements OpenYoloWithTimeoutApi {
 
   constructor(
       private frameManager: ProviderFrameElement,
-      private channel: SecureChannel) {
-    this.navigatorCredentials = createNavigatorCredentialsApi();
+      private channel: SecureChannel,
+      fallbackApi?: OpenYoloApi) {
+    this.navigatorCredentials = fallbackApi || createNavigatorCredentialsApi();
   }
 
   async hintsAvailable(

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -152,7 +152,6 @@ export class NoOpNavigatorCredentials implements OpenYoloApi {
 
   async hint(options?: OpenYoloCredentialHintOptions):
       Promise<OpenYoloCredential> {
-    // Reject with a canceled error as no hints can be retrieved.
     throw OpenYoloInternalError.noCredentialsAvailable().toExposedError();
   }
 

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -16,6 +16,7 @@
 
 import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
 import {OpenYoloInternalError} from '../protocol/errors';
+import {isSecureOrigin} from '../protocol/utils';
 
 import {OpenYoloApi} from './api';
 
@@ -259,11 +260,11 @@ export class NavigatorCredentials implements OpenYoloApi {
 
 /**
  * Returns the navigator.credentials wrapper according to the environment. If
- * navigator.credentials is not defined, it will create a n-op version of the
- * API.
+ * navigator.credentials is not defined, or the current app not on https,
+ * it will create a no-op version of the API.
  */
 export function createNavigatorCredentialsApi(): OpenYoloApi {
-  if (navigator.credentials !== undefined) {
+  if (navigator.credentials !== undefined && isSecureOrigin()) {
     return new NavigatorCredentials(navigator.credentials);
   }
   return new NoOpNavigatorCredentials();

--- a/ts/protocol/utils.ts
+++ b/ts/protocol/utils.ts
@@ -129,6 +129,13 @@ export function stringValidator(value: any): boolean {
 }
 
 /**
+ * Returns true if the current origin is https.
+ */
+export function isSecureOrigin(): boolean {
+  return window.location.protocol === 'https:';
+}
+
+/**
  * Utility to handle a promise result. It allows for more readable code
  * as this pattern is often used.
  */

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -254,24 +254,24 @@ export class ProviderFrame {
       requestId: string,
       options: OpenYoloCredentialHintOptions) {
     console.info('Handling hint request');
-
-    let hints = await this.cancellablePromise(this.getHints(options));
-    if (hints.length < 1) {
-      console.info('no hints available');
-      this.clientChannel.send(msg.errorMessage(
-          requestId,
-          OpenYoloInternalError.noCredentialsAvailable().toExposedError()));
-      return;
-    }
-
-    // user interaction is required. instruct the interaction provider to show
-    // a picker for the available credentials.
-    let selectionPromise = this.interactionProvider.showHintPicker(
-        hints, options, this.createDisplayCallbacks(requestId));
-
-    // now, wait for selection to occur, and send the selection result to the
-    // client
     try {
+      let hints = await this.cancellablePromise(this.getHints(options));
+      if (hints.length < 1) {
+        console.info('no hints available');
+        this.clientChannel.send(msg.errorMessage(
+            requestId,
+            OpenYoloInternalError.noCredentialsAvailable().toExposedError()));
+        return;
+      }
+
+      // user interaction is required. instruct the interaction provider to show
+      // a picker for the available credentials.
+      let selectionPromise = this.interactionProvider.showHintPicker(
+          hints, options, this.createDisplayCallbacks(requestId));
+
+
+      // now, wait for selection to occur, and send the selection result to the
+      // client
       console.info('awaiting user selection of hint');
       let selectedHint = await this.cancellablePromise(selectionPromise);
 
@@ -297,7 +297,6 @@ export class ProviderFrame {
           msg.credentialResultMessage(requestId, selectedHint));
     } catch (err) {
       this.handleWellKnownErrors(err);
-      console.info(`Hint selection cancelled: ${err}`);
       if (err instanceof OpenYoloInternalError) {
         this.clientChannel.send(
             msg.errorMessage(requestId, err.toExposedError()));
@@ -324,58 +323,60 @@ export class ProviderFrame {
       requestId: string,
       options: OpenYoloCredentialRequestOptions) {
     console.info('Handling credential retrieve request');
+    try {
+      let credentials = await this.cancellablePromise(
+          this.credentialDataProvider.getAllCredentials(
+              this.equivalentAuthDomains, options));
 
-    let credentials = await this.cancellablePromise(
-        this.credentialDataProvider.getAllCredentials(
-            this.equivalentAuthDomains, options));
+      // filter out the credentials which don't match the request options
+      let pertinentCredentials =
+          credentials.filter((credential: OpenYoloCredential) => {
+            return options.supportedAuthMethods.find(
+                (value) => value === credential.authMethod);
+          });
 
-    // filter out the credentials which don't match the request options
-    let pertinentCredentials =
-        credentials.filter((credential: OpenYoloCredential) => {
-          return options.supportedAuthMethods.find(
-              (value) => value === credential.authMethod);
-        });
-
-    // if no credentials are available, directly respond to the client that
-    // this is the case and the request will complete
-    if (pertinentCredentials.length < 1) {
-      console.info('no credentials available');
-      this.clientChannel.send(msg.errorMessage(
-          requestId,
-          OpenYoloInternalError.noCredentialsAvailable().toExposedError()));
-      return;
-    }
-
-    console.info('credentials are available');
-
-    // if a single credential is available, check if auto sign-in is enabled
-    // for the client authentication domain. If it is, directly return the
-    // credential to the client, and the request will complete.
-    if (pertinentCredentials.length === 1) {
-      let autoSignInEnabled = await this.localStateProvider.isAutoSignInEnabled(
-          this.clientAuthDomain);
-      console.log(`single credential, auto sign in = ${autoSignInEnabled}`);
-      if (autoSignInEnabled) {
-        const credential = pertinentCredentials[0];
-        // Display the auto sign in screen and send the message.
-        await this.cancellablePromise(this.interactionProvider.showAutoSignIn(
-            credential, this.createDisplayCallbacks(requestId)));
-        this.clientChannel.send(msg.credentialResultMessage(
-            requestId, this.storeForProxyLogin(credential)));
+      // if no credentials are available, directly respond to the client that
+      // this is the case and the request will complete
+      if (pertinentCredentials.length < 1) {
+        console.info('no credentials available');
+        this.clientChannel.send(msg.errorMessage(
+            requestId,
+            OpenYoloInternalError.noCredentialsAvailable().toExposedError()));
         return;
       }
-    }
 
-    // user interaction is required. instruct the interaction provider to show
-    // a picker for the available credentials, and concurrently notify the
-    // client to show the provider frame.
-    console.info('User interaction required to release credential');
-    let selectionPromise = this.interactionProvider.showCredentialPicker(
-        pertinentCredentials, options, this.createDisplayCallbacks(requestId));
+      console.info('credentials are available');
 
-    // now, wait for selection to occur, and send the selection result to the
-    // client
-    try {
+      // if a single credential is available, check if auto sign-in is enabled
+      // for the client authentication domain. If it is, directly return the
+      // credential to the client, and the request will complete.
+      if (pertinentCredentials.length === 1) {
+        let autoSignInEnabled =
+            await this.localStateProvider.isAutoSignInEnabled(
+                this.clientAuthDomain);
+        console.log(`single credential, auto sign in = ${autoSignInEnabled}`);
+        if (autoSignInEnabled) {
+          const credential = pertinentCredentials[0];
+          // Display the auto sign in screen and send the message.
+          await this.cancellablePromise(this.interactionProvider.showAutoSignIn(
+              credential, this.createDisplayCallbacks(requestId)));
+          this.clientChannel.send(msg.credentialResultMessage(
+              requestId, this.storeForProxyLogin(credential)));
+          return;
+        }
+      }
+
+      // user interaction is required. instruct the interaction provider to show
+      // a picker for the available credentials, and concurrently notify the
+      // client to show the provider frame.
+      console.info('User interaction required to release credential');
+      let selectionPromise = this.interactionProvider.showCredentialPicker(
+          pertinentCredentials,
+          options,
+          this.createDisplayCallbacks(requestId));
+
+      // now, wait for selection to occur, and send the selection result to the
+      // client
       let selectedCredential = await this.cancellablePromise(selectionPromise);
 
       // once selected we want to set auto sign in enabled to true again

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,16 +6204,9 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
This avoid "requestFailed" error when navigator.credentials operations are called on http (i.e. E2E tests).

Also fixed `hintsAvailable` not triggering the fallback.