### PR TITLE
Add the ability to set custom log levels

### DIFF
--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
+import {LogLevel, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
 import {OpenYoloInternalError} from '../protocol/errors';
 import {SecureChannel} from '../protocol/secure_channel';
 import {PromiseResolver, TimeoutRacer} from '../protocol/utils';
@@ -28,6 +28,7 @@ import {DisableAutoSignIn} from './disable_auto_sign_in';
 import {HintAvailableRequest} from './hint_available_request';
 import {HintRequest} from './hint_request';
 import {ProxyLogin} from './proxy_login';
+import {SetLogLevelRequest} from './set_log_level_request';
 
 type OpenYoloWithTimeoutApiMethods = keyof OpenYoloWithTimeoutApi;
 
@@ -73,6 +74,7 @@ describe('OpenYolo API', () => {
         'proxyLogin',
         'disableAutoSignIn',
         'cancelLastOperation',
+        'setLogLevel',
         'dispose'
       ]);
     });
@@ -255,6 +257,16 @@ describe('OpenYolo API', () => {
           done();
         });
       });
+
+      it('setLogLevel', (done) => {
+        openYoloApiImplSpy.setLogLevel.and.returnValue(Promise.resolve());
+        openyolo.setLogLevel(LogLevel.INFO).then(() => {
+          expect(openYoloApiImplSpy.setLogLevel)
+              .toHaveBeenCalledWith(LogLevel.INFO, jasmine.any(Object));
+          done();
+        });
+      });
+
     });
   });
 
@@ -276,7 +288,8 @@ describe('OpenYolo API', () => {
         'save',
         'proxyLogin',
         'disableAutoSignIn',
-        'cancelLastOperation'
+        'cancelLastOperation',
+        'setLogLevel'
       ]);
       const frameManager =
           jasmine.createSpyObj('ProviderFrameElement', ['display']);
@@ -435,5 +448,19 @@ describe('OpenYolo API', () => {
         });
       });
     });
+
+    describe('setLogLevel', () => {
+      it('dispatches the request and calls navigator.credentials', (done) => {
+        spyOn(SetLogLevelRequest.prototype, 'dispatch')
+            .and.returnValue(Promise.resolve());
+
+        openYoloApiImpl.setLogLevel(LogLevel.INFO, timeoutRacerSpy).then(() => {
+          expect(SetLogLevelRequest.prototype.dispatch)
+              .toHaveBeenCalledWith(LogLevel.INFO, timeoutRacerSpy);
+          done();
+        });
+      });
+    });
+
   });
 });

--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import {LogLevel} from '../protocol/data';
 import {OpenYoloError, OpenYoloErrorType, OpenYoloExposedErrorData, OpenYoloInternalError} from '../protocol/errors';
+import {log} from '../protocol/logger';
 import {RpcMessageArgumentTypes, RpcMessageData, RpcMessageType} from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {generateId, PromiseResolver, startTimeoutRacer, TimeoutRacer} from '../protocol/utils';
@@ -115,7 +117,7 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
   }
 
   protected debugLog(message: string) {
-    console.debug(`(rq-${this.id}): ` + message);
+    log(LogLevel.DEBUG, `(rq-${this.id}): ` + message);
   }
 
   protected getPromise(): Promise<ResultT> {

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -15,6 +15,7 @@
  */
 
 import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from '../protocol/data';
+import {LogLevel} from '../protocol/data';
 import {OpenYoloInternalError} from '../protocol/errors';
 import {isSecureOrigin} from '../protocol/utils';
 
@@ -161,6 +162,8 @@ export class NoOpNavigatorCredentials implements OpenYoloApi {
 
   async cancelLastOperation(): Promise<void> {}
 
+  async setLogLevel(level: LogLevel): Promise<void> {}
+
   async proxyLogin(credential: OpenYoloCredential):
       Promise<OpenYoloProxyLoginResponse> {
     throw OpenYoloInternalError
@@ -187,6 +190,8 @@ export class NavigatorCredentials implements OpenYoloApi {
       return;
     }
   }
+
+  async setLogLevel(level: LogLevel): Promise<void> {}
 
   async retrieve(options?: OpenYoloCredentialRequestOptions):
       Promise<OpenYoloCredential> {

--- a/ts/api/set_log_level_request_test.ts
+++ b/ts/api/set_log_level_request_test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LogLevel} from '../protocol/data';
+import {setLogLevelMessage, setLogLevelResultMessage} from '../protocol/rpc_messages';
+import {SecureChannel} from '../protocol/secure_channel';
+import {FakeProviderConnection} from '../test_utils/channels';
+import {createSpyFrame} from '../test_utils/frames';
+
+import {SetLogLevelRequest} from './set_log_level_request';
+
+
+describe('SetLogLevelRequest', () => {
+  let request: SetLogLevelRequest;
+  let clientChannel: SecureChannel;
+  let providerChannel: SecureChannel;
+  let frame: any;
+
+  beforeEach(() => {
+    let connection = new FakeProviderConnection();
+    clientChannel = connection.clientChannel;
+    providerChannel = connection.providerChannel;
+    frame = createSpyFrame('frameId');
+    request = new SetLogLevelRequest(frame, clientChannel);
+    spyOn(request, 'dispose').and.callThrough();
+  });
+
+  afterEach(() => {
+    request.dispose();
+  });
+
+  describe('dispatch', () => {
+    it('should send a RPC message to the frame', () => {
+      spyOn(clientChannel, 'send').and.callThrough();
+      request.dispatch(LogLevel.DEBUG);
+      expect(clientChannel.send)
+          .toHaveBeenCalledWith(setLogLevelMessage(request.id, LogLevel.DEBUG));
+    });
+  });
+
+  it('should resolve the promise once operation is successful',
+     async function(done) {
+       let promise = request.dispatch(LogLevel.DEBUG);
+       providerChannel.send(setLogLevelResultMessage(request.id));
+       try {
+         let result = await promise;
+         expect(result).toBeFalsy();
+         expect(request.dispose).toHaveBeenCalled();
+         done();
+       } catch (err) {
+         done.fail('Promise should resolve');
+       }
+     });
+});

--- a/ts/protocol/comms.ts
+++ b/ts/protocol/comms.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import {LogLevel} from '../protocol/data';
+import {log} from '../protocol/logger';
+
 import {isOpenYoloMessageFormat, Message, MESSAGE_DATA_VALIDATORS, MessageData, MessageType} from './messages';
 import {PostMessageData, PostMessageType} from './post_messages';
 import {RpcMessageData, RpcMessageType} from './rpc_messages';
@@ -68,14 +71,14 @@ export function createMessageListener<T extends MessageType>(
     type: T, listener: MessageListener<T>): FilteringEventListener {
   let messageListener = (ev: MessageEvent) => {
     if (!isOpenYoloMessageFormat(ev.data)) {
-      console.debug('non openyolo message received');
+      log(LogLevel.DEBUG, 'non openyolo message received');
       return false;
     }
     if (ev.data['type'] !== type) return false;
 
     let validator = MESSAGE_DATA_VALIDATORS[(type as MessageType)];
     if (!validator(ev.data['data'])) {
-      console.debug(`message of type ${type} received with invalid data`);
+      log(LogLevel.DEBUG, `message of type ${type} received with invalid data`);
       return false;
     }
     listener(ev.data['data'], ev.data['type'], ev);

--- a/ts/protocol/data.ts
+++ b/ts/protocol/data.ts
@@ -236,3 +236,9 @@ export const TOKEN_PROVIDERS = indexedStrEnum({
   GOOGLE: boxEnum('https://accounts.google.com'),
   MICROSOFT: boxEnum('https://login.live.com'),
 });
+
+/**
+ * The set of log levels that can be used with the OpenYOLO library.
+ */
+export const enum LogLevel {ERROR = 0, WARNING = 1, INFO = 2, DEBUG = 3}
+;

--- a/ts/protocol/logger.ts
+++ b/ts/protocol/logger.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LogLevel} from './data';
+import {OpenYoloInternalError} from './errors';
+
+// default log level
+// only log errors
+export const DEFAULT_LOG_LEVEL = LogLevel.WARNING;
+
+// the current log level
+let LOG_LEVEL = DEFAULT_LOG_LEVEL;
+
+// enforcing a slightly stricter contract than console
+type Logger = (message: string, ...args: any[]) => void;
+
+// enforce exhaustive checks on log levels
+function shouldNeverHappen(level: never): never {
+  throw OpenYoloInternalError.requestFailed('Invalid log level');
+}
+
+function getLogger(level: LogLevel): Logger {
+  switch (level) {
+    case LogLevel.DEBUG:
+      return console.log.bind(console);
+    case LogLevel.INFO:
+      return console.info.bind(console);
+    case LogLevel.WARNING:
+      return console.warn.bind(console);
+    case LogLevel.ERROR:
+      return console.error.bind(console);
+    default:
+      return shouldNeverHappen(level);
+  }
+}
+
+function isLoggable(level: LogLevel): boolean {
+  return level <= LOG_LEVEL;
+}
+
+export function setLogLevel(level: LogLevel) {
+  LOG_LEVEL = level;
+}
+
+export function log(level: LogLevel, message: string, ...args: any[]) {
+  if (!isLoggable(level)) {
+    return;
+  }
+
+  const length = args ? args.length : 0;
+  if (length > 0) {
+    getLogger(level)(message, ...args);
+  } else {
+    getLogger(level)(message);
+  }
+}

--- a/ts/protocol/logger_test.ts
+++ b/ts/protocol/logger_test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 The OpenYOLO for Web Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LogLevel} from './data';
+import {DEFAULT_LOG_LEVEL, log, setLogLevel} from './logger';
+
+describe('Logger Tests', () => {
+
+  let errorHandler: jasmine.Spy;
+  let warnHandler: jasmine.Spy;
+  let infoHandler: jasmine.Spy;
+  let debugHandler: jasmine.Spy;
+
+  beforeEach(() => {
+    errorHandler = spyOn(console, 'error').and.callThrough();
+    warnHandler = spyOn(console, 'warn').and.callThrough();
+    infoHandler = spyOn(console, 'info').and.callThrough();
+    debugHandler = spyOn(console, 'log').and.callThrough();
+    setLogLevel(DEFAULT_LOG_LEVEL);
+  });
+
+  it('Should find an appropriate logger for every log level', (done) => {
+    setLogLevel(LogLevel.DEBUG);
+    log(LogLevel.DEBUG, 'debug');
+    log(LogLevel.INFO, 'info');
+    log(LogLevel.WARNING, 'warning');
+    log(LogLevel.ERROR, 'error');
+    expect(debugHandler).toHaveBeenCalled();
+    expect(infoHandler).toHaveBeenCalled();
+    expect(warnHandler).toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalled();
+    done();
+  });
+
+  describe('Should log at the appropriate log levels', () => {
+    it('Should only log warn|error messages at default log level', (done) => {
+      log(LogLevel.DEBUG, 'debug');
+      log(LogLevel.INFO, 'info');
+      log(LogLevel.WARNING, 'warning');
+      log(LogLevel.ERROR, 'error');
+      expect(debugHandler).toHaveBeenCalledTimes(0);
+      expect(infoHandler).toHaveBeenCalledTimes(0);
+      expect(warnHandler).toHaveBeenCalledTimes(1);
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      done();
+    });
+
+    it('Should respect log level overrides to info', (done) => {
+      setLogLevel(LogLevel.INFO);
+      log(LogLevel.DEBUG, 'debug');
+      log(LogLevel.INFO, 'info');
+      log(LogLevel.WARNING, 'warning');
+      log(LogLevel.ERROR, 'error');
+      expect(debugHandler).toHaveBeenCalledTimes(0);
+      expect(infoHandler).toHaveBeenCalledTimes(1);
+      expect(warnHandler).toHaveBeenCalledTimes(1);
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      done();
+    });
+
+    it('Should respect log level overrides to warn', (done) => {
+      setLogLevel(LogLevel.WARNING);
+      log(LogLevel.DEBUG, 'debug');
+      log(LogLevel.INFO, 'info');
+      log(LogLevel.WARNING, 'warning');
+      log(LogLevel.ERROR, 'error');
+      expect(debugHandler).toHaveBeenCalledTimes(0);
+      expect(infoHandler).toHaveBeenCalledTimes(0);
+      expect(warnHandler).toHaveBeenCalledTimes(1);
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+      done();
+    });
+
+  });
+});

--- a/ts/protocol/rpc_messages.ts
+++ b/ts/protocol/rpc_messages.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from './data';
+import {LogLevel, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions, OpenYoloProxyLoginResponse} from './data';
 import {OpenYoloError, OpenYoloExposedErrorData} from './errors';
-import {DataValidator, isBoolean, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
+import {DataValidator, isBoolean, isNumber, isUndefined, isValidCredential, isValidDisplayOptions, isValidError, isValidHintOptions, isValidProxyLoginResponse, isValidRequestOptions} from './validators';
 
 export const enum RpcMessageType {
   disableAutoSignIn = 'disableAutoSignIn',
@@ -33,7 +33,9 @@ export const enum RpcMessageType {
   credential = 'credential',
   error = 'error',
   cancelLastOperation = 'cancelLastOperation',
-  cancelLastOperationResult = 'cancelLastOperationResult'
+  cancelLastOperationResult = 'cancelLastOperationResult',
+  setLogLevel = 'setLogLevel',
+  setLogLevelResult = 'setLogLevelResult'
 }
 
 // Hack to be able to use the list of values of the const enum above.
@@ -70,7 +72,9 @@ export type RpcMessageArgumentTypes = {
   'credential': OpenYoloCredential,
   'error': OpenYoloExposedErrorData,
   'cancelLastOperation': undefined,
-  'cancelLastOperationResult': undefined
+  'cancelLastOperationResult': undefined,
+  'setLogLevel': LogLevel,
+  'setLogLevelResult': undefined
 };
 
 export interface RpcMessageData<T extends RpcMessageType> {
@@ -112,7 +116,9 @@ export const RPC_MESSAGE_DATA_VALIDATORS: RpcMessageDataValidators = {
   'credential': rpcDataValidator(isValidCredential),
   'error': rpcDataValidator(isValidError),
   'cancelLastOperation': rpcDataValidator(isUndefined),
-  'cancelLastOperationResult': rpcDataValidator(isUndefined)
+  'cancelLastOperationResult': rpcDataValidator(isUndefined),
+  'setLogLevel': rpcDataValidator(isNumber),
+  'setLogLevelResult': rpcDataValidator(isUndefined)
 };
 
 export interface DisplayOptions {
@@ -192,4 +198,12 @@ export function cancelLastOperationMessage(id: string) {
 
 export function cancelLastOperationResultMessage(id: string) {
   return rpcMessage(RpcMessageType.cancelLastOperationResult, id, undefined);
+}
+
+export function setLogLevelMessage(id: string, level: LogLevel) {
+  return rpcMessage(RpcMessageType.setLogLevel, id, level);
+}
+
+export function setLogLevelResultMessage(id: string) {
+  return rpcMessage(RpcMessageType.setLogLevelResult, id, undefined);
 }

--- a/ts/protocol/secure_channel.ts
+++ b/ts/protocol/secure_channel.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import {LogLevel} from '../protocol/data';
+import {log} from '../protocol/logger';
+
 import {createMessageListener, FilteringEventListener, isPermittedOrigin, RpcMessageListener, WindowLike} from './comms';
 import {OpenYoloError, OpenYoloInternalError} from './errors';
 import {ackMessage, channelConnectMessage, channelReadyMessage, PostMessageType, readyForConnectMessage} from './post_messages';
@@ -199,7 +202,7 @@ export class SecureChannel {
   }
 
   private static debugLog(role: string, message: string) {
-    console.debug(`(${role}) ${message}`);
+    log(LogLevel.DEBUG, `(${role}) ${message}`);
   }
 
   constructor(private port: MessagePort, private providerEnd: boolean) {

--- a/ts/protocol/validators.ts
+++ b/ts/protocol/validators.ts
@@ -34,6 +34,10 @@ export function isBoolean(value?: any): boolean {
   return typeof value === 'boolean';
 }
 
+export function isNumber(value?: any): boolean {
+  return typeof value === 'number';
+}
+
 export function isWebUrl(value?: any): boolean {
   if (!isNonEmptyString(value)) {
     return false;

--- a/ts/spi/ancestor_origin_verifier.ts
+++ b/ts/spi/ancestor_origin_verifier.ts
@@ -15,7 +15,9 @@
  */
 
 import {createMessageListener, isPermittedOrigin, sendMessage, WindowLike} from '../protocol/comms';
+import {LogLevel} from '../protocol/data';
 import {OpenYoloInternalError} from '../protocol/errors';
+import {log} from '../protocol/logger';
 import {PostMessageType, verifyPingMessage} from '../protocol/post_messages';
 import {generateId, TimeoutPromiseResolver} from '../protocol/utils';
 
@@ -135,17 +137,19 @@ export class AncestorOriginVerifier {
 
           // We either resolve or reject according to the origin.
           if (isPermittedOrigin(ev.origin, this.permittedOrigins)) {
-            console.debug(`verification of ancestor ${parentDepth} succeeded`);
+            log(LogLevel.DEBUG,
+                `verification of ancestor ${parentDepth} succeeded`);
             promiseResolver.resolve(ev.origin);
           } else {
-            console.warn(`untrusted domain in ancestor chain: ${ev.origin}`);
+            log(LogLevel.WARNING,
+                `untrusted domain in ancestor chain: ${ev.origin}`);
             promiseResolver.reject(
                 OpenYoloInternalError.untrustedOrigin(ev.origin));
           }
         });
 
     this.providerFrame.addEventListener('message', listener);
-    console.debug(`sending verification ping to ancestor ${parentDepth}`);
+    log(LogLevel.DEBUG, `sending verification ping to ancestor ${parentDepth}`);
     sendMessage(ancestorFrame, verifyPingMessage(verifyId));
     try {
       return await promiseResolver.promise;

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -15,8 +15,9 @@
  */
 
 import {PrimaryClientConfiguration} from '../protocol/client_config';
-import {AUTHENTICATION_METHODS, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from '../protocol/data';
+import {AUTHENTICATION_METHODS, LogLevel, OpenYoloCredential, OpenYoloCredentialHintOptions, OpenYoloCredentialRequestOptions} from '../protocol/data';
 import {OpenYoloErrorType, OpenYoloInternalError} from '../protocol/errors';
+import * as logger from '../protocol/logger';  // using the * syntax for jasmine tests
 import * as msg from '../protocol/rpc_messages';
 import {SecureChannel} from '../protocol/secure_channel';
 import {PromiseResolver} from '../protocol/utils';
@@ -284,6 +285,20 @@ describe('ProviderFrame', () => {
             });
 
         clientChannel.send(msg.disableAutoSignInMessage(requestId));
+      });
+    });
+
+    describe('handling setLogLevelRequest', () => {
+      it('should call setLogLevel', async function(done) {
+        let logLevel = LogLevel.INFO;
+        let setLogLevelSpy = spyOn(logger, 'setLogLevel').and.callThrough();
+        clientChannel.listen(
+            msg.RpcMessageType.setLogLevelResult, async function(res) {
+              expect(setLogLevelSpy).toHaveBeenCalledWith(logLevel);
+              done();
+            });
+
+        clientChannel.send(msg.setLogLevelMessage(requestId, logLevel));
       });
     });
 

--- a/tsconfig-karma.json
+++ b/tsconfig-karma.json
@@ -7,6 +7,7 @@
       "es2015.core",
       "es2015.promise",
       "es2015.symbol",
+      "es2015.iterable",
       "dom"
     ],
     "importHelpers": true,

--- a/tsconfig-publish-es5.json
+++ b/tsconfig-publish-es5.json
@@ -7,6 +7,7 @@
       "es2015.core",
       "es2015.promise",
       "es2015.symbol",
+      "es2015.iterable",
       "dom"
     ],
     "importHelpers": true,

--- a/tsconfig-publish-es6.json
+++ b/tsconfig-publish-es6.json
@@ -7,6 +7,7 @@
       "es2015.core",
       "es2015.promise",
       "es2015.symbol",
+      "es2015.iterable",
       "dom"
     ],
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "es2015.core",
       "es2015.promise",
       "es2015.symbol",
+      "es2015.iterable",
       "dom"
     ],
     "importHelpers": true,


### PR DESCRIPTION
This adds a new API `setLogLevel(...)` which helps us control the extent to which we log.

The default log level is set to `LogLevel.WARN`.
