### PR TITLE
Remove debug logging

### DIFF
--- a/ts/api/base_request.ts
+++ b/ts/api/base_request.ts
@@ -89,7 +89,6 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
    * proper initialization.
    */
   private registerBaseHandlers() {
-    this.debugLog('request instantiated');
     // Register a standard error handler.
     this.registerHandler(
         RpcMessageType.error, (data: OpenYoloExposedErrorData) => {
@@ -100,7 +99,6 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
             error = OpenYoloInternalError.unknownError().toExposedError();
           }
 
-          this.debugLog(`request failed: ${error}`);
           this.reject(error);
           this.dispose();
         });
@@ -112,10 +110,6 @@ export abstract class BaseRequest<ResultT, OptionsT> implements
       this.clearTimeout();
       this.frame.display(options);
     });
-  }
-
-  protected debugLog(message: string) {
-    console.debug(`(rq-${this.id}): ` + message);
   }
 
   protected getPromise(): Promise<ResultT> {

--- a/ts/api/hint_request.ts
+++ b/ts/api/hint_request.ts
@@ -39,7 +39,6 @@ export class HintRequest extends
    * Handles the initial response from a hint request.
    */
   private handleResult(credential: OpenYoloCredential): void {
-    this.debugLog(`Hint request complete`);
     this.resolve(credential);
     this.dispose();
   }

--- a/ts/api/verify.ts
+++ b/ts/api/verify.ts
@@ -25,7 +25,6 @@ export function respondToHandshake(window: WindowLike): void {
   }
   listener =
       createMessageListener(PostMessageType.verifyPing, (data, type, ev) => {
-        console.debug(`responding to ping from ${ev.origin}`);
         sendMessage(ev.source, verifyAckMessage(data), ev.origin);
       });
   window.addEventListener('message', listener);

--- a/ts/protocol/comms.ts
+++ b/ts/protocol/comms.ts
@@ -68,14 +68,12 @@ export function createMessageListener<T extends MessageType>(
     type: T, listener: MessageListener<T>): FilteringEventListener {
   let messageListener = (ev: MessageEvent) => {
     if (!isOpenYoloMessageFormat(ev.data)) {
-      console.debug('non openyolo message received');
       return false;
     }
     if (ev.data['type'] !== type) return false;
 
     let validator = MESSAGE_DATA_VALIDATORS[(type as MessageType)];
     if (!validator(ev.data['data'])) {
-      console.debug(`message of type ${type} received with invalid data`);
       return false;
     }
     listener(ev.data['data'], ev.data['type'], ev);

--- a/ts/protocol/secure_channel_test.ts
+++ b/ts/protocol/secure_channel_test.ts
@@ -85,7 +85,7 @@ describe('SecureChannel', () => {
       spyOn(port, 'removeEventListener').and.callThrough();
       spyOn(port, 'postMessage').and.callThrough();
       spyOn(port, 'close').and.callThrough();
-      channel = new SecureChannel(port, false);
+      channel = new SecureChannel(port);
     });
 
     it('sends messages', () => {

--- a/ts/spi/ancestor_origin_verifier.ts
+++ b/ts/spi/ancestor_origin_verifier.ts
@@ -135,7 +135,6 @@ export class AncestorOriginVerifier {
 
           // We either resolve or reject according to the origin.
           if (isPermittedOrigin(ev.origin, this.permittedOrigins)) {
-            console.debug(`verification of ancestor ${parentDepth} succeeded`);
             promiseResolver.resolve(ev.origin);
           } else {
             console.warn(`untrusted domain in ancestor chain: ${ev.origin}`);
@@ -145,7 +144,6 @@ export class AncestorOriginVerifier {
         });
 
     this.providerFrame.addEventListener('message', listener);
-    console.debug(`sending verification ping to ancestor ${parentDepth}`);
     sendMessage(ancestorFrame, verifyPingMessage(verifyId));
     try {
       return await promiseResolver.promise;

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -221,12 +221,10 @@ describe('ProviderFrame', () => {
       requestId = '' + Math.floor(Math.random() * 1000000);
 
       clientChannel.addFallbackListener((ev) => {
-        console.log(`unexpected message on client: ${JSON.stringify(ev)}`);
         unexpectedClientMessages.push(ev);
       });
 
       providerChannel.addFallbackListener((ev) => {
-        console.log(`unexpected message on provider: ${JSON.stringify(ev)}`);
         unexpectedProviderMessages.push(ev);
       });
     });
@@ -951,7 +949,6 @@ class TestLocalStateProvider implements LocalStateProvider {
     } else {
       result = true;
     }
-    console.debug(`auto sign in ${result} for domain ${authDomain}`);
     return result;
   }
 

--- a/ts/test_utils/channels.ts
+++ b/ts/test_utils/channels.ts
@@ -93,7 +93,7 @@ export class FakeProviderConnection {
     this.messageChannel = new FakeMessageChannel();
     this.clientPort = this.messageChannel.port1;
     this.providerPort = this.messageChannel.port2;
-    this.clientChannel = new SecureChannel(this.clientPort, false);
-    this.providerChannel = new SecureChannel(this.providerPort, true);
+    this.clientChannel = new SecureChannel(this.clientPort);
+    this.providerChannel = new SecureChannel(this.providerPort);
   }
 }


### PR DESCRIPTION
Consumers of the library have complained that we are overly verbose
in our console logging; this has now been stripped back to just
key informational and error logs.