### PR TITLE
Updated to only use Credentials Management when it releases passwords plain text

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@angular/router": ">=4.0.0-beta <5.0.0",
     "@types/jasmine": "^2.5.43",
     "@types/text-encoding": "0.0.30",
-    "@types/webappsec-credential-management": "^0.2.0",
+    "@types/webappsec-credential-management": "^0.3.1",
     "clang-format": "^1.0.46",
     "codecov": "^2.1.0",
     "codelyzer": "~2.0.0",

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -268,7 +268,7 @@ export function createNavigatorCredentialsApi(): OpenYoloApi {
   // As per
   // https://developers.google.com/web/updates/2017/06/credential-management-updates#feature_detection_needs_attention,
   // we check for the presence of preventSilentAccess in navigator.credentials
-  // that is a fewture of M60+. Previous versions would not release plain-text
+  // that is a feature of M60+. Previous versions would not release plain-text
   // passwords.
   if (typeof navigator.credentials !== 'undefined' &&
       typeof navigator.credentials.preventSilentAccess === 'function' &&

--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -53,19 +53,21 @@ function convertRequestOptions(options?: OpenYoloCredentialRequestOptions):
  */
 function convertCredentialToOpenYolo(credential: PasswordCredential|
                                      FederatedCredential): OpenYoloCredential {
-  let authMethod = credential.type === 'federated' ?
+  const authMethod = credential.type === 'federated' ?
       (credential as FederatedCredential).provider :
       AUTHENTICATION_METHODS.ID_AND_PASSWORD;
 
-  let convertedCredential: OpenYoloCredential = {
+  const convertedCredential: OpenYoloCredential = {
     id: credential.id,
     authMethod: authMethod,
     displayName: credential.name || undefined,
     profilePicture: credential.iconURL || undefined,
-    // navigator.credentials do not pass the password directly, so proxyLogin
-    // has to be used.
-    proxiedAuthRequired: credential.type === 'password'
+    proxiedAuthRequired: false
   };
+  // Chrome M60+ returns the password.
+  if (credential instanceof PasswordCredential) {
+    convertedCredential.password = credential.password;
+  }
 
   return convertedCredential;
 }
@@ -76,7 +78,7 @@ function convertCredentialToOpenYolo(credential: PasswordCredential|
 function convertCredentialFromOpenYolo(credential: OpenYoloCredential):
     Credential {
   if (credential.authMethod === AUTHENTICATION_METHODS.ID_AND_PASSWORD) {
-    let convertedCredential = new PasswordCredential({
+    const convertedCredential = new PasswordCredential({
       id: credential.id,
       type: 'password',
       name: credential.displayName,
@@ -85,7 +87,7 @@ function convertCredentialFromOpenYolo(credential: OpenYoloCredential):
     } as PasswordCredentialData);
     return convertedCredential;
   } else {
-    let convertedCredential = new FederatedCredential({
+    const convertedCredential = new FederatedCredential({
       id: credential.id,
       name: credential.displayName,
       iconURL: credential.profilePicture,
@@ -263,7 +265,14 @@ export class NavigatorCredentials implements OpenYoloApi {
  * it will create a no-op version of the API.
  */
 export function createNavigatorCredentialsApi(): OpenYoloApi {
-  if (navigator.credentials !== undefined && isSecureOrigin()) {
+  // As per
+  // https://developers.google.com/web/updates/2017/06/credential-management-updates#feature_detection_needs_attention,
+  // we check for the presence of preventSilentAccess in navigator.credentials
+  // that is a fewture of M60+. Previous versions would not release plain-text
+  // passwords.
+  if (typeof navigator.credentials !== 'undefined' &&
+      typeof navigator.credentials.preventSilentAccess === 'function' &&
+      isSecureOrigin()) {
     return new NavigatorCredentials(navigator.credentials);
   }
   return new NoOpNavigatorCredentials();

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -51,14 +51,13 @@ describe('NavigatorCredentials', () => {
       const options: OpenYoloCredentialRequestOptions = {
         supportedAuthMethods: [AUTHENTICATION_METHODS.GOOGLE]
       };
-      const federatedCredential: FederatedCredential = {
+      const federatedCredential = new FederatedCredential({
         provider: AUTHENTICATION_METHODS.GOOGLE,
-        protocol: null,
+        protocol: 'protocol',
         name: 'Name',
-        iconURL: 'icon.jpg',
-        type: 'federated',
+        iconURL: 'https://www.example.com/icon.jpg',
         id: 'user@example.com'
-      };
+      });
       spyOn(cmApi, 'get').and.returnValue(Promise.resolve(federatedCredential));
       navigatorCredentials.retrieve(options).then(credential => {
         expect(cmApi.get).toHaveBeenCalledWith(jasmine.objectContaining({
@@ -71,7 +70,7 @@ describe('NavigatorCredentials', () => {
           id: 'user@example.com',
           authMethod: AUTHENTICATION_METHODS.GOOGLE,
           displayName: 'Name',
-          profilePicture: 'icon.jpg',
+          profilePicture: 'https://www.example.com/icon.jpg',
           proxiedAuthRequired: false
         });
         done();
@@ -82,15 +81,16 @@ describe('NavigatorCredentials', () => {
       const options: OpenYoloCredentialRequestOptions = {
         supportedAuthMethods: [AUTHENTICATION_METHODS.ID_AND_PASSWORD]
       };
-      const passwordCredential: PasswordCredential = {
+      const passwordCredential = new PasswordCredential({
         name: 'Name',
-        iconURL: 'icon.jpg',
+        iconURL: 'https://www.example.com/icon.jpg',
         type: 'password',
         id: 'user@example.com',
         idName: 'username',
         passwordName: 'password',
+        password: 'password',
         additionalData: null
-      };
+      });
       spyOn(cmApi, 'get').and.returnValue(Promise.resolve(passwordCredential));
       navigatorCredentials.retrieve(options).then(credential => {
         expect(cmApi.get).toHaveBeenCalledWith(jasmine.objectContaining({
@@ -102,8 +102,9 @@ describe('NavigatorCredentials', () => {
           id: 'user@example.com',
           authMethod: AUTHENTICATION_METHODS.ID_AND_PASSWORD,
           displayName: 'Name',
-          profilePicture: 'icon.jpg',
-          proxiedAuthRequired: true
+          profilePicture: 'https://www.example.com/icon.jpg',
+          proxiedAuthRequired: false,
+          password: 'password'
         }));
         done();
       });

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -53,7 +53,7 @@ describe('NavigatorCredentials', () => {
       };
       const federatedCredential = new FederatedCredential({
         provider: AUTHENTICATION_METHODS.GOOGLE,
-        protocol: 'protocol',
+        protocol: 'openidconnect',
         name: 'Name',
         iconURL: 'https://www.example.com/icon.jpg',
         id: 'user@example.com'

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,9 +175,9 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.30.tgz#2ad7bc19287094c9d2754d238e0994dd2995781f"
 
-"@types/webappsec-credential-management@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@types/webappsec-credential-management/-/webappsec-credential-management-0.2.0.tgz#c84fe1ee14aefcae1d80e1fe77cff91e0b06e9c3"
+"@types/webappsec-credential-management@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/webappsec-credential-management/-/webappsec-credential-management-0.3.1.tgz#768324830f28bbe6dbc2eac0a65822da6b2a93e1"
 
 abbrev@1:
   version "1.1.0"


### PR DESCRIPTION
It uses the `preventSilentAccess` method to detect this.