### PR TITLE
Fix requests timeout

### DIFF
--- a/ts/api/api.ts
+++ b/ts/api/api.ts
@@ -395,33 +395,51 @@ export class InitializeOnDemandApi implements OnDemandOpenYoloApi {
    * the provider page to check the user's configuration, and initialize the
    * correct implementation of OpenYolo based on the result.
    */
-  static async createOpenYoloApi(
+  static createOpenYoloApi(
       timeoutRacer: TimeoutRacer,
       providerUrlBase: string,
       renderMode: RenderMode|null,
       preloadRequest?: PreloadRequest): Promise<OpenYoloWithTimeoutApi> {
-    try {
-      // Sanitize input.
-      renderMode = verifyOrDetectRenderMode(renderMode);
+    let frameManager: ProviderFrameElement|null = null;
+    // Sanitize input.
+    const renderModeSanitized = verifyOrDetectRenderMode(renderMode);
+    const instanceId = generateId();
+    // It is not great to use promise here. But using try/catch and await, it is
+    // not possible to properly dispose of a potentially initialized
+    // frameManager if an error happens in the way. I have no idea why, but the
+    // typechecking engine of TypeScript considers that the framemanager can
+    // never be initialized within the try block.
+    return Promise.resolve()
+        .then(() => {
+          return timeoutRacer.race(sha256(instanceId));
+        })
+        .then((instanceIdHash) => {
+          frameManager = new ProviderFrameElement(
+              document,
+              instanceIdHash,
+              window.location.origin,
+              renderModeSanitized,
+              providerUrlBase,
+              preloadRequest);
 
-      const instanceId = generateId();
-      const instanceIdHash = await timeoutRacer.race(sha256(instanceId));
-      const frameManager = new ProviderFrameElement(
-          document,
-          instanceIdHash,
-          window.location.origin,
-          renderMode,
-          providerUrlBase,
-          preloadRequest);
-
-      const channel = await timeoutRacer.race(SecureChannel.clientConnect(
-          window, frameManager.getContentWindow(), instanceId, instanceIdHash));
-      return new OpenYoloApiImpl(frameManager, channel);
-    } catch (e) {
-      timeoutRacer.rethrowUnlessTimeoutError(e);
-      // Convert the timeout error.
-      throw OpenYoloInternalError.requestTimeout().toExposedError();
-    }
+          return timeoutRacer.race(SecureChannel.clientConnect(
+              window,
+              frameManager.getContentWindow(),
+              instanceId,
+              instanceIdHash));
+        })
+        .then((channel) => {
+          return new OpenYoloApiImpl(frameManager!, channel);
+        })
+        .catch((e) => {
+          // Dispose of the frame managerif it was created.
+          if (frameManager !== null) {
+            frameManager.dispose();
+          }
+          timeoutRacer.rethrowUnlessTimeoutError(e);
+          // Convert the timeout error.
+          throw OpenYoloInternalError.requestTimeout().toExposedError();
+        });
   }
 
   setProviderUrlBase(providerUrlBase: string) {

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -27,6 +27,7 @@ import {CredentialSave} from './credential_save';
 import {DisableAutoSignIn} from './disable_auto_sign_in';
 import {HintAvailableRequest} from './hint_available_request';
 import {HintRequest} from './hint_request';
+import {ProviderFrameElement} from './provider_frame_elem';
 import {ProxyLogin} from './proxy_login';
 
 type OpenYoloWithTimeoutApiMethods = keyof OpenYoloWithTimeoutApi;
@@ -102,6 +103,7 @@ describe('OpenYolo API', () => {
     it('secure channel connection fails', (done) => {
       spyOn(SecureChannel, 'clientConnect')
           .and.returnValue(Promise.reject(expectedError));
+      spyOn(ProviderFrameElement.prototype, 'dispose');
       // The operation does not matter here.
       openyolo.cancelLastOperation().then(
           () => {
@@ -109,6 +111,7 @@ describe('OpenYolo API', () => {
           },
           (error) => {
             expect(error).toBe(expectedError);
+            expect(ProviderFrameElement.prototype.dispose).toHaveBeenCalled();
             openyolo.reset();
             done();
           });

--- a/ts/api/api_test.ts
+++ b/ts/api/api_test.ts
@@ -284,7 +284,8 @@ describe('OpenYolo API', () => {
           jasmine.createSpyObj('ProviderFrameElement', ['display']);
       openYoloApiImpl = new OpenYoloApiImpl(
           frameManager, secureChannelSpy, navCredentialsSpy);
-      timeoutRacerSpy = jasmine.createSpyObj('TimeoutRacer', ['race']);
+      timeoutRacerSpy =
+          jasmine.createSpyObj('TimeoutRacer', ['race', 'hasTimedOut']);
     });
 
     type methodSignatures =
@@ -321,6 +322,7 @@ describe('OpenYolo API', () => {
       });
 
       it('propagates error', (done) => {
+        timeoutRacerSpy.hasTimedOut.and.returnValue(false);
         dispatchSpy.and.returnValue(Promise.reject(otherError));
         (openYoloApiImpl[methodName] as methodSignatures[M])(
             options, timeoutRacerSpy)
@@ -334,7 +336,27 @@ describe('OpenYolo API', () => {
                 });
       });
 
+      it('captures timeout and cancel operation', (done) => {
+        // Simulate timeout error.
+        timeoutRacerSpy.hasTimedOut.and.returnValue(true);
+        dispatchSpy.and.returnValue(Promise.reject(otherError));
+        spyOn(CancelLastOperationRequest.prototype, 'dispatch');
+        (openYoloApiImpl[methodName] as methodSignatures[M])(
+            options, timeoutRacerSpy)
+            .then(
+                () => {
+                  done.fail('Should not resolve!');
+                },
+                (error: Error) => {
+                  expect(error).toBe(otherError);
+                  expect(CancelLastOperationRequest.prototype.dispatch)
+                      .toHaveBeenCalledWith(undefined, undefined);
+                  done();
+                });
+      });
+
       it('delegates to credential', (done) => {
+        timeoutRacerSpy.hasTimedOut.and.returnValue(false);
         dispatchSpy.and.returnValue(Promise.reject(wrapBrowserError));
         navCredentialsSpy[methodName].and.returnValue(
             Promise.resolve(expectedResult));
@@ -435,6 +457,25 @@ describe('OpenYolo API', () => {
           expect(navCredentialsSpy.disableAutoSignIn).toHaveBeenCalled();
           done();
         });
+      });
+
+      it('captures timeout and cancel operation', (done) => {
+        // Simulate timeout error.
+        timeoutRacerSpy.hasTimedOut.and.returnValue(true);
+        spyOn(DisableAutoSignIn.prototype, 'dispatch')
+            .and.returnValue(Promise.reject(otherError));
+        spyOn(CancelLastOperationRequest.prototype, 'dispatch');
+        openYoloApiImpl.disableAutoSignIn(timeoutRacerSpy)
+            .then(
+                () => {
+                  done.fail('Should not resolve!');
+                },
+                (error: Error) => {
+                  expect(error).toBe(otherError);
+                  expect(CancelLastOperationRequest.prototype.dispatch)
+                      .toHaveBeenCalledWith(undefined, undefined);
+                  done();
+                });
       });
     });
   });

--- a/ts/protocol/utils_test.ts
+++ b/ts/protocol/utils_test.ts
@@ -72,7 +72,11 @@ describe('utils', () => {
     it('does nothing if promise resolves before timeout', (done) => {
       const timeoutRacer = utils.startTimeoutRacer(100);
       const promiseResolver = new utils.PromiseResolver<void>();
-      timeoutRacer.race(promiseResolver.promise).then(done);
+      expect(timeoutRacer.hasTimedOut()).toBe(false);
+      timeoutRacer.race(promiseResolver.promise).then(() => {
+        expect(timeoutRacer.hasTimedOut()).toBe(false);
+        done();
+      });
       jasmine.clock().tick(99);
       promiseResolver.resolve();
     });
@@ -80,6 +84,7 @@ describe('utils', () => {
     it('does reject if timeout', (done) => {
       const timeoutRacer = utils.startTimeoutRacer(100);
       const promiseResolver = new utils.PromiseResolver<void>();
+      expect(timeoutRacer.hasTimedOut()).toBe(false);
       timeoutRacer.race(promiseResolver.promise)
           .then(
               () => {
@@ -87,6 +92,7 @@ describe('utils', () => {
               },
               (error) => {
                 expect(error.message).toEqual('The timeout has expired.');
+                expect(timeoutRacer.hasTimedOut()).toBe(true);
                 done();
               });
       jasmine.clock().tick(100);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,16 +6605,9 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-ws@1.1.2:
+ws@1.1.2, ws@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
Fix two issues:

- if the global timeout ends after the iframe initialization but before the resolution of an operation, it currently makes it impossible to perform the operation again because it is still pending on the provider side. To address the issue, a global request timeout triggers a cancel last operation.
- Dispose of the iframe if initialization failed to avoid clobbering the DOM.