### PR TITLE
Fixed disableAutoSignIn when using navigator.credentials

### DIFF
--- a/ts/api/navigator_credentials.ts
+++ b/ts/api/navigator_credentials.ts
@@ -183,7 +183,7 @@ export class NavigatorCredentials implements OpenYoloApi {
 
   async disableAutoSignIn(): Promise<void> {
     try {
-      return await this.cmApi.requireUserMediation();
+      return await this.cmApi.preventSilentAccess();
     } catch (e) {
       // Ignore error (i.e. non secure origins for instance).
       return;

--- a/ts/api/navigator_credentials_test.ts
+++ b/ts/api/navigator_credentials_test.ts
@@ -35,12 +35,12 @@ describe('NavigatorCredentials', () => {
 
   describe('disableAutoSignIn', () => {
     it('resolves when success', (done) => {
-      spyOn(cmApi, 'requireUserMediation').and.returnValue(Promise.resolve());
+      spyOn(cmApi, 'preventSilentAccess').and.returnValue(Promise.resolve());
       navigatorCredentials.disableAutoSignIn().then(done);
     });
 
     it('resolves when insecure origin error', (done) => {
-      spyOn(cmApi, 'requireUserMediation')
+      spyOn(cmApi, 'preventSilentAccess')
           .and.returnValue(Promise.reject(new Error('Insecure origin!')));
       navigatorCredentials.disableAutoSignIn().then(done);
     });


### PR DESCRIPTION
Call `preventSilentAccess` instead of the old API, `requireUserMediation`.