### PR TITLE
Fix issue when resizing the IFrame that would reset the previously set dimensions

### DIFF
--- a/ts/api/provider_frame_elem.ts
+++ b/ts/api/provider_frame_elem.ts
@@ -100,9 +100,11 @@ export class ProviderFrameElement {
    * Displays the container.
    */
   display(options: DisplayOptions): void {
-    this.resetStyle();
-    this.applyStyle(FRAME_RENDER_MODE_STYLE_MAPPING[this.renderMode]);
-    this.frameElem.hidden = false;
+    if (this.frameElem.hidden) {
+      this.resetStyle();
+      this.applyStyle(FRAME_RENDER_MODE_STYLE_MAPPING[this.renderMode]);
+      this.frameElem.hidden = false;
+    }
     if ((options.height || options.width) &&
         this.renderMode !== RenderMode.fullScreen) {
       if (options.height) this.frameElem.style.height = `${options.height}px`;

--- a/ts/api/provider_frame_elem_test.ts
+++ b/ts/api/provider_frame_elem_test.ts
@@ -113,8 +113,35 @@ describe('ProviderFrameElement', () => {
         expect(iframeElement.hidden).toBe(false);
       });
 
+      it('displays with default after displayed and hidden', () => {
+        providerFrame.display({height: 300, width: 400});
+        providerFrame.hide();
+        providerFrame.display({});
+        expect(iframeElement.style.display).toEqual('');
+        expect(iframeElement.style.height).toEqual('320px');
+        expect(iframeElement.style.width).toEqual('320px');
+        expect(iframeElement.style.bottom).toEqual('');
+        expect(iframeElement.style.left).toEqual('');
+        expect(iframeElement.style.right).toEqual('0px');
+        expect(iframeElement.style.top).toEqual('0px');
+        expect(iframeElement.hidden).toBe(false);
+      });
+
       it('displays with the given height and width', () => {
         providerFrame.display({height: 300, width: 400});
+        expect(iframeElement.style.display).toEqual('');
+        expect(iframeElement.style.height).toEqual('300px');
+        expect(iframeElement.style.width).toEqual('400px');
+        expect(iframeElement.style.bottom).toEqual('');
+        expect(iframeElement.style.left).toEqual('');
+        expect(iframeElement.style.right).toEqual('0px');
+        expect(iframeElement.style.top).toEqual('0px');
+        expect(iframeElement.hidden).toBe(false);
+      });
+
+      it('displays with the given height, and then width', () => {
+        providerFrame.display({height: 300});
+        providerFrame.display({width: 400});
         expect(iframeElement.style.display).toEqual('');
         expect(iframeElement.style.height).toEqual('300px');
         expect(iframeElement.style.width).toEqual('400px');


### PR DESCRIPTION
When another display message is sent, it would always reset the style, thus overwriting a previously custom height or width set. It now ensures to only reset the styles if the iframe is hidden.