### PR TITLE
Use a more general error message when Yolo initialization fails.

### DIFF
--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -251,9 +251,10 @@ export class OpenYoloInternalError implements CustomError {
     return new OpenYoloInternalError({
       code: InternalErrorCode.requestTimeout,
       exposedErrorType: OpenYoloErrorType.requestFailed,
-      message: 'The API request timed out. This may occur for requsts from ' +
-          'unregistered origin. Please check current origin has been ' +
-          'registered on your OAuth client.'
+      message: 'The API request timed out. This may occur when error is ' +
+          'returned upon initialization. If you are using Google Yolo, ' +
+          'this error could happen if you use a valid client ID with an ' +
+          'unregistered origin.'
     });
   }
 

--- a/ts/protocol/errors.ts
+++ b/ts/protocol/errors.ts
@@ -253,8 +253,8 @@ export class OpenYoloInternalError implements CustomError {
       exposedErrorType: OpenYoloErrorType.requestFailed,
       message: 'The API request timed out. This may occur when error is ' +
           'returned upon initialization. If you are using Google Yolo, ' +
-          'this error could happen if you use a valid client ID with an ' +
-          'unregistered origin.'
+          'this error could happen if you haven\'t registered the origin ' +
+          'with your OAuth client.'
     });
   }
 


### PR DESCRIPTION
The message should be composed in a way that is general enough to be used in all identity providers and also give a concrete example for the error.