### PR TITLE
Add an optional 'options' parameter to ShowAutoSignIn

### DIFF
--- a/demo/provider/barbican/openyolo_provider/openyolo_provider.component.ts
+++ b/demo/provider/barbican/openyolo_provider/openyolo_provider.component.ts
@@ -162,7 +162,8 @@ export class OpenYoloProviderComponent implements OnInit, OnDestroy,
 
   async showAutoSignIn(
       credential: Credential,
-      displayCallbacks: DisplayCallbacks): Promise<any> {
+      displayCallbacks: DisplayCallbacks,
+      options: CredentialRequestOptions): Promise<any> {
     return;
   }
 

--- a/externs/openyolo.js
+++ b/externs/openyolo.js
@@ -244,11 +244,12 @@ let InteractionProvider = function() {};
 /**
  * @param {!Credential} credential
  * @param {!DisplayCallbacks} displayCallbacks
+ * @param {!CredentialRequestOptions=} options
  * @return {!Promise<undefined>}
  * @export
  */
 InteractionProvider.prototype.showAutoSignIn = function(
-    credential, displayCallbacks) {};
+    credential, displayCallbacks, options) {};
 
 /**
  * @param {!Array<!Credential>} credentials

--- a/ts/spi/provider_config.ts
+++ b/ts/spi/provider_config.ts
@@ -165,7 +165,8 @@ export interface InteractionProvider {
    */
   showAutoSignIn(
       credential: OpenYoloCredential,
-      displayCallbacks: DisplayCallbacks): Promise<any>;
+      displayCallbacks: DisplayCallbacks,
+      options: OpenYoloCredentialRequestOptions): Promise<any>;
 
   /**
    * Requests the immediate tear down of any presently active UI.

--- a/ts/spi/provider_frame.ts
+++ b/ts/spi/provider_frame.ts
@@ -365,7 +365,7 @@ export class ProviderFrame {
           const credential = pertinentCredentials[0];
           // Display the auto sign in screen and send the message.
           await this.cancellablePromise(this.interactionProvider.showAutoSignIn(
-              credential, this.createDisplayCallbacks(requestId)));
+              credential, this.createDisplayCallbacks(requestId), options));
           this.clientChannel.send(msg.credentialResultMessage(
               requestId, this.storeForProxyLogin(credential)));
           return;

--- a/ts/spi/provider_frame_test.ts
+++ b/ts/spi/provider_frame_test.ts
@@ -310,7 +310,8 @@ describe('ProviderFrame', () => {
            (interactionProvider.showAutoSignIn as jasmine.Spy)
                .and.callFake(
                    (credential: OpenYoloCredential,
-                    displayCallbacks: DisplayCallbacks) => {
+                    displayCallbacks: DisplayCallbacks,
+                    options: OpenYoloCredentialRequestOptions) => {
                      expect(credential).toBe(alicePwdCred);
                      return Promise.resolve();
                    });
@@ -331,7 +332,8 @@ describe('ProviderFrame', () => {
         (interactionProvider.showAutoSignIn as jasmine.Spy)
             .and.callFake(
                 (credential: OpenYoloCredential,
-                 displayCallbacks: DisplayCallbacks) => {
+                 displayCallbacks: DisplayCallbacks,
+                 options: OpenYoloCredentialRequestOptions) => {
                   expect(credential).toBe(alicePwdCred);
                   // return a promise that's not going to resolve
                   return new Promise<void>((resolve, reject) => {});


### PR DESCRIPTION
In some cases, ShowAutoSignIn still needs the CredentialRequestOptions as a parameter. This parameter is optional because we don't want the current API to be affected.